### PR TITLE
Feature/reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and lightbox behavior, plus reply and missing-origin fallback handling
 - Executable chat E2E presence scenarios for standard member states
   (online, away, offline) with sidebar status-dot verification
+- Message reactions with add/remove support, grouped emoji counters, and
+  incremental live updates in timeline rendering
+- Advanced reaction emoji picker with category tabs, shortcode conversion
+  (for example `:wave:` to `👋`), and user-scoped frequent emojis
+- Additional reaction coverage in unit and E2E tests for Matrix toggle logic,
+  aggregation mapping, and message-level reaction UI behavior
 
 ### Changed
 
@@ -55,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `login.steps.mjs` and `chat.steps.mjs`
 - Synapse environment validation moved from scenario-level Given setup into
   hook-based prechecks for seeded-room scenarios
+- Message action bar now uses icon-only reply/reaction controls with compact
+  gray styling and native button tooltips
+- Chat page media helper logic was moved into `useChatMedia` to reduce page
+  size and improve composable reuse
 
 ### Fixed
 

--- a/app/components/Chat/MessageActionBar.vue
+++ b/app/components/Chat/MessageActionBar.vue
@@ -1,15 +1,65 @@
 <script setup lang="ts">
 import { useAppI18n } from "~/composables/useAppI18n";
+import { onBeforeUnmount, ref } from "vue";
 
 const emit = defineEmits<{
   reply: [];
+  reactionPick: [emoji: string];
 }>();
 
 const { translateText } = useAppI18n();
+const pickerOpen = ref(false);
+const customEmoji = ref("");
+const pickerRoot = ref<HTMLElement | null>(null);
+
+const quickReactions = ["👍", "❤️", "😂", "🎉", "😮", "😢", "🙏", "🔥"];
+
+function emitReaction(emoji: string) {
+  const trimmedEmoji = emoji.trim();
+  if (!trimmedEmoji) {
+    return;
+  }
+  emit("reactionPick", trimmedEmoji);
+  customEmoji.value = "";
+  pickerOpen.value = false;
+}
+
+function submitCustomEmoji() {
+  emitReaction(customEmoji.value);
+}
+
+function togglePicker() {
+  pickerOpen.value = !pickerOpen.value;
+}
+
+function onDocumentClick(clickEvent: MouseEvent) {
+  if (!pickerOpen.value || !pickerRoot.value) {
+    return;
+  }
+  const clickTarget = clickEvent.target;
+  if (!(clickTarget instanceof Node)) {
+    return;
+  }
+  if (!pickerRoot.value.contains(clickTarget)) {
+    pickerOpen.value = false;
+  }
+}
+
+if (import.meta.client) {
+  document.addEventListener("click", onDocumentClick);
+}
+
+onBeforeUnmount(() => {
+  if (!import.meta.client) {
+    return;
+  }
+  document.removeEventListener("click", onDocumentClick);
+});
 </script>
 
 <template>
   <div
+    ref="pickerRoot"
     :class="[
       'pointer-events-none absolute -top-3 right-0 z-10 opacity-0',
       'transition-opacity duration-150',
@@ -18,18 +68,72 @@ const { translateText } = useAppI18n();
     ]"
   >
     <div
-      class="flex items-center gap-1 rounded-md border border-gray-200 bg-white px-1 py-1 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+      class="
+        flex items-center gap-1 rounded-md border border-gray-200 bg-white
+        px-1 py-1 shadow-sm dark:border-gray-700 dark:bg-gray-800
+      "
     >
       <UButton
         type="button"
         size="xs"
         color="neutral"
         variant="ghost"
+        icon="i-lucide-smile-plus"
+        aria-label="Add reaction"
+        title="Reaktion hinzufügen"
+        class="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
+        @click.stop="togglePicker"
+      />
+      <UButton
+        type="button"
+        size="xs"
+        color="neutral"
+        variant="ghost"
+        icon="i-lucide-reply"
         :aria-label="translateText('chat.replyAction')"
+        :title="translateText('chat.replyAction')"
+        class="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
         @click="emit('reply')"
-      >
-        {{ translateText("chat.replyAction") }}
-      </UButton>
+      />
+    </div>
+    <div
+      v-if="pickerOpen"
+      class="mt-1 w-56 rounded-md border border-gray-200 bg-white p-2 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+      @click.stop
+    >
+      <div class="grid grid-cols-4 gap-1">
+        <button
+          v-for="emoji in quickReactions"
+          :key="emoji"
+          type="button"
+          class="rounded px-2 py-1 text-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+          :data-emoji-option="emoji"
+          @click="emitReaction(emoji)"
+        >
+          {{ emoji }}
+        </button>
+      </div>
+      <div class="mt-2 flex items-center gap-1">
+        <input
+          v-model="customEmoji"
+          type="text"
+          placeholder="Any emoji"
+          class="
+            w-full rounded border border-gray-200 bg-white px-2 py-1 text-xs
+            dark:border-gray-600 dark:bg-gray-900
+          "
+          @keydown.enter.prevent="submitCustomEmoji"
+        />
+        <UButton
+          type="button"
+          size="xs"
+          color="neutral"
+          variant="soft"
+          @click="submitCustomEmoji"
+        >
+          Add
+        </UButton>
+      </div>
     </div>
   </div>
 </template>

--- a/app/components/Chat/MessageActionBar.vue
+++ b/app/components/Chat/MessageActionBar.vue
@@ -6,13 +6,13 @@ const emit = defineEmits<{
   reply: [];
   reactionPick: [emoji: string];
 }>();
+const props = defineProps<{
+  frequentScopeKey?: string;
+}>();
 
 const { translateText } = useAppI18n();
 const pickerOpen = ref(false);
-const customEmoji = ref("");
 const pickerRoot = ref<HTMLElement | null>(null);
-
-const quickReactions = ["👍", "❤️", "😂", "🎉", "😮", "😢", "🙏", "🔥"];
 
 function emitReaction(emoji: string) {
   const trimmedEmoji = emoji.trim();
@@ -20,12 +20,7 @@ function emitReaction(emoji: string) {
     return;
   }
   emit("reactionPick", trimmedEmoji);
-  customEmoji.value = "";
   pickerOpen.value = false;
-}
-
-function submitCustomEmoji() {
-  emitReaction(customEmoji.value);
 }
 
 function togglePicker() {
@@ -78,7 +73,7 @@ onBeforeUnmount(() => {
         size="xs"
         color="neutral"
         variant="ghost"
-        icon="i-lucide-smile-plus"
+        icon="i-lucide-smile"
         aria-label="Add reaction"
         title="Reaktion hinzufügen"
         class="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
@@ -98,42 +93,13 @@ onBeforeUnmount(() => {
     </div>
     <div
       v-if="pickerOpen"
-      class="mt-1 w-56 rounded-md border border-gray-200 bg-white p-2 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+      class="mt-1"
       @click.stop
     >
-      <div class="grid grid-cols-4 gap-1">
-        <button
-          v-for="emoji in quickReactions"
-          :key="emoji"
-          type="button"
-          class="rounded px-2 py-1 text-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
-          :data-emoji-option="emoji"
-          @click="emitReaction(emoji)"
-        >
-          {{ emoji }}
-        </button>
-      </div>
-      <div class="mt-2 flex items-center gap-1">
-        <input
-          v-model="customEmoji"
-          type="text"
-          placeholder="Any emoji"
-          class="
-            w-full rounded border border-gray-200 bg-white px-2 py-1 text-xs
-            dark:border-gray-600 dark:bg-gray-900
-          "
-          @keydown.enter.prevent="submitCustomEmoji"
-        />
-        <UButton
-          type="button"
-          size="xs"
-          color="neutral"
-          variant="soft"
-          @click="submitCustomEmoji"
-        >
-          Add
-        </UButton>
-      </div>
+      <ChatReactionEmojiPicker
+        :frequent-scope-key="props.frequentScopeKey"
+        @select="emitReaction"
+      />
     </div>
   </div>
 </template>

--- a/app/components/Chat/MessageItem.vue
+++ b/app/components/Chat/MessageItem.vue
@@ -43,6 +43,7 @@ const props = defineProps<{
   message: MessageItem;
   displayUrl?: string;
   loadingMedia?: boolean;
+  currentUserId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -93,6 +94,7 @@ function handlePickerReaction(emoji: string) {
     ]"
   >
     <ChatMessageActionBar
+      :frequent-scope-key="props.currentUserId"
       @reply="emit('reply')"
       @reaction-pick="handlePickerReaction"
     />

--- a/app/components/Chat/MessageItem.vue
+++ b/app/components/Chat/MessageItem.vue
@@ -26,6 +26,12 @@ interface MessageItem {
     body: string;
   };
   media?: MediaInfo;
+  reactions?: Array<{
+    emoji: string;
+    count: number;
+    hasOwnReaction: boolean;
+    ownReactionEventIds: string[];
+  }>;
   readBy?: Array<{
     userId: string;
     displayName: string;
@@ -42,7 +48,27 @@ const props = defineProps<{
 const emit = defineEmits<{
   reply: [];
   openLightbox: [];
+  toggleReaction: [payload: {
+    messageId: string;
+    emoji: string;
+    ownReactionEventIds: string[];
+  }];
 }>();
+
+function emitToggleReaction(emoji: string, ownReactionEventIds: string[] = []) {
+  emit("toggleReaction", {
+    messageId: props.message.id,
+    emoji,
+    ownReactionEventIds,
+  });
+}
+
+function handlePickerReaction(emoji: string) {
+  const existingReaction = props.message.reactions?.find((reaction) => {
+    return reaction.emoji === emoji;
+  });
+  emitToggleReaction(emoji, existingReaction?.ownReactionEventIds ?? []);
+}
 </script>
 
 <template>
@@ -66,7 +92,10 @@ const emit = defineEmits<{
       'hover:bg-gray-50 dark:hover:bg-gray-900/60'
     ]"
   >
-    <ChatMessageActionBar @reply="emit('reply')" />
+    <ChatMessageActionBar
+      @reply="emit('reply')"
+      @reaction-pick="handlePickerReaction"
+    />
     <div class="flex items-start gap-3">
       <img
         v-if="message.avatarUrl"
@@ -128,6 +157,27 @@ const emit = defineEmits<{
         <p v-else class="text-sm wrap-break-word">
           {{ message.body }}
         </p>
+        <div
+          v-if="message.reactions && message.reactions.length > 0"
+          class="mt-2 flex flex-wrap gap-1"
+        >
+          <button
+            v-for="reaction in message.reactions"
+            :key="`${message.id}-${reaction.emoji}`"
+            type="button"
+            :data-reaction-chip="reaction.emoji"
+            class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors"
+            :class="
+              reaction.hasOwnReaction
+                ? 'border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-500/70 dark:bg-blue-950/60 dark:text-blue-200'
+                : 'border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+            "
+            @click="emitToggleReaction(reaction.emoji, reaction.ownReactionEventIds)"
+          >
+            <span>{{ reaction.emoji }}</span>
+            <span>{{ reaction.count }}</span>
+          </button>
+        </div>
 
         <div
           v-if="message.readBy && message.readBy.length > 0"

--- a/app/components/Chat/MessageList.vue
+++ b/app/components/Chat/MessageList.vue
@@ -55,6 +55,7 @@ const props = defineProps<{
   canLoadOlder?: boolean;
   loadingOlder?: boolean;
   resolveMediaBlobUrl?: MediaResolver;
+  currentUserId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -168,6 +169,7 @@ watch(
           :message="msg"
           :display-url="getDisplayUrl(msg)"
           :loading-media="Boolean(loadingMedia[msg.id])"
+          :current-user-id="props.currentUserId"
           @reply="emitReplyTarget(msg)"
           @toggle-reaction="emit('toggleReaction', $event)"
           @open-lightbox="openLightbox(msg)"

--- a/app/components/Chat/MessageList.vue
+++ b/app/components/Chat/MessageList.vue
@@ -30,6 +30,12 @@ interface MessageItem {
     body: string;
   };
   media?: MediaInfo;
+  reactions?: Array<{
+    emoji: string;
+    count: number;
+    hasOwnReaction: boolean;
+    ownReactionEventIds: string[];
+  }>;
   readBy?: Array<{
     userId: string;
     displayName: string;
@@ -54,6 +60,11 @@ const props = defineProps<{
 const emit = defineEmits<{
   loadOlder: [];
   reply: [target: { eventId: string; senderName: string; body: string }];
+  toggleReaction: [payload: {
+    messageId: string;
+    emoji: string;
+    ownReactionEventIds: string[];
+  }];
 }>();
 
 const { translateText } = useAppI18n();
@@ -158,6 +169,7 @@ watch(
           :display-url="getDisplayUrl(msg)"
           :loading-media="Boolean(loadingMedia[msg.id])"
           @reply="emitReplyTarget(msg)"
+          @toggle-reaction="emit('toggleReaction', $event)"
           @open-lightbox="openLightbox(msg)"
         />
       </div>

--- a/app/components/Chat/ReactionEmojiPicker.vue
+++ b/app/components/Chat/ReactionEmojiPicker.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import {
+  categoryOrder,
+  createShortcodeMap,
+  defaultFrequentEmojis,
+  emojiCatalog,
+  getFrequentEmojis,
+  loadFrequentEmojiUsage,
+  normalizeShortcodes,
+  saveFrequentEmojiUsage,
+  trackEmojiUsage,
+  type EmojiCategoryId,
+} from "~/composables/useEmojiPickerData";
+
+const emit = defineEmits<{
+  select: [emoji: string];
+}>();
+const props = defineProps<{
+  frequentScopeKey?: string;
+}>();
+
+const activeCategory = ref<EmojiCategoryId>("frequent");
+const searchTerm = ref("");
+const customEmoji = ref("");
+const frequentUsage = ref<Record<string, number>>({});
+const shortcodeToEmoji = createShortcodeMap(emojiCatalog);
+
+watch(
+  () => props.frequentScopeKey,
+  (scopeKey) => {
+    frequentUsage.value = loadFrequentEmojiUsage(scopeKey);
+  },
+  { immediate: true }
+);
+
+const frequentEmojis = computed(() => {
+  return getFrequentEmojis(frequentUsage.value, defaultFrequentEmojis, 16);
+});
+
+function selectEmoji(emoji: string) {
+  frequentUsage.value = trackEmojiUsage(frequentUsage.value, emoji);
+  saveFrequentEmojiUsage(frequentUsage.value, props.frequentScopeKey);
+  emit("select", emoji);
+}
+
+function addFromInput() {
+  const normalizedInput = normalizeShortcodes(
+    customEmoji.value,
+    shortcodeToEmoji
+  ).trim();
+  if (!normalizedInput) {
+    return;
+  }
+  selectEmoji(normalizedInput);
+  customEmoji.value = "";
+}
+
+const filteredEntries = computed(() => {
+  const normalizedQuery = searchTerm.value.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return emojiCatalog;
+  }
+  return emojiCatalog.filter((emojiEntry) => {
+    if (emojiEntry.emoji.includes(normalizedQuery)) {
+      return true;
+    }
+    if (emojiEntry.name.includes(normalizedQuery)) {
+      return true;
+    }
+    if (
+      emojiEntry.shortcodes.some((shortcode) => {
+        return shortcode.includes(normalizedQuery);
+      })
+    ) {
+      return true;
+    }
+    return emojiEntry.keywords.some((keyword) => {
+      return keyword.includes(normalizedQuery);
+    });
+  });
+});
+
+const sections = computed(() => {
+  const entries = filteredEntries.value;
+  if (searchTerm.value.trim()) {
+    return categoryOrder
+      .filter((category) => category.id !== "frequent")
+      .map((category) => {
+        return {
+          ...category,
+          emojis: entries.filter((emojiEntry) => {
+            return emojiEntry.category === category.id;
+          }),
+        };
+      })
+      .filter((section) => section.emojis.length > 0);
+  }
+
+  if (activeCategory.value === "frequent") {
+    return [
+      {
+        id: "frequent",
+        label: "Quick Reactions",
+        icon: "🕘",
+        emojis: frequentEmojis.value.map((emoji) => ({ emoji })),
+      },
+    ];
+  }
+
+  const category = categoryOrder.find((item) => item.id === activeCategory.value);
+  if (!category) {
+    return [];
+  }
+  return [
+    {
+      ...category,
+      emojis: entries.filter((emojiEntry) => {
+        return emojiEntry.category === category.id;
+      }),
+    },
+  ];
+});
+</script>
+
+<template>
+  <div
+    class="
+      mt-1 w-80 rounded-lg border border-gray-200 bg-white p-2 shadow-xl
+      dark:border-gray-700 dark:bg-gray-900
+    "
+  >
+    <div
+      class="
+        mb-2 flex items-center gap-1 border-b border-gray-200 pb-1
+        dark:border-gray-700
+      "
+    >
+      <button
+        v-for="category in categoryOrder"
+        :key="category.id"
+        type="button"
+        :title="category.label"
+        class="rounded p-1.5 text-sm transition-colors"
+        :class="
+          activeCategory === category.id
+            ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+            : `
+              text-gray-500 hover:bg-gray-100 hover:text-gray-800
+              dark:text-gray-300 dark:hover:bg-gray-800
+              dark:hover:text-gray-100
+            `
+        "
+        @click="activeCategory = category.id"
+      >
+        {{ category.icon }}
+      </button>
+    </div>
+
+    <div class="mb-2">
+      <input
+        v-model="searchTerm"
+        type="text"
+        placeholder="Search"
+        class="
+          w-full rounded-md border border-gray-200 bg-white px-3 py-1.5
+          text-sm dark:border-gray-600 dark:bg-gray-800
+        "
+      />
+    </div>
+
+    <div class="max-h-56 space-y-2 overflow-y-auto pr-1">
+      <section
+        v-for="section in sections"
+        :key="section.id"
+      >
+        <p class="mb-1 text-xs font-semibold text-gray-500 dark:text-gray-300">
+          {{ section.label }}
+        </p>
+        <div class="grid grid-cols-8 gap-1">
+          <button
+            v-for="emojiEntry in section.emojis"
+            :key="emojiEntry.emoji"
+            type="button"
+            class="
+              rounded p-1 text-lg transition-colors hover:bg-gray-100
+              dark:hover:bg-gray-800
+            "
+            :data-emoji-option="emojiEntry.emoji"
+            @click="selectEmoji(emojiEntry.emoji)"
+          >
+            {{ emojiEntry.emoji }}
+          </button>
+        </div>
+      </section>
+    </div>
+
+    <div
+      class="
+        mt-2 flex items-center gap-1 border-t border-gray-200 pt-2
+        dark:border-gray-700
+      "
+    >
+      <input
+        v-model="customEmoji"
+        type="text"
+        placeholder="Any emoji or :wave:"
+        class="
+          w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-xs
+          dark:border-gray-600 dark:bg-gray-800
+        "
+        @keydown.enter.prevent="addFromInput"
+      />
+      <button
+        type="button"
+        class="
+          rounded px-2 py-1 text-xs font-semibold text-blue-600
+          hover:bg-blue-50 dark:text-blue-300 dark:hover:bg-blue-950/40
+        "
+        @click="addFromInput"
+      >
+        Add
+      </button>
+    </div>
+  </div>
+</template>

--- a/app/composables/useChatMedia.ts
+++ b/app/composables/useChatMedia.ts
@@ -1,0 +1,193 @@
+import type { Ref } from "vue";
+import { decryptMediaBlob, fetchMediaBlob } from "~/utils/mediaUtils";
+
+interface MediaPayload {
+  mxcUrl: string;
+  mimetype?: string;
+  isEncrypted?: boolean;
+  encryptionInfo?: Record<string, any>;
+}
+
+export function useChatMedia(client: Ref<Record<string, any> | null>) {
+  function appendAccessTokenToMediaUrl(
+    avatarUrl: string | null | undefined,
+  ): string | undefined {
+    if (!avatarUrl) {
+      return undefined;
+    }
+    const matrixClient = client.value;
+    const accessToken = matrixClient?.getAccessToken?.();
+    if (!accessToken || !avatarUrl.includes("/_matrix/")) {
+      return avatarUrl;
+    }
+    if (avatarUrl.includes("access_token=")) {
+      return avatarUrl;
+    }
+    const separator = avatarUrl.includes("?") ? "&" : "?";
+    return `${avatarUrl}${separator}access_token=${encodeURIComponent(accessToken)}`;
+  }
+
+  function getSpaceAvatarUrl(
+    spaceRoom: Record<string, any>,
+  ): string | undefined {
+    const matrixClient = client.value;
+    const homeserverUrl = matrixClient?.getHomeserverUrl?.();
+    const getAvatarUrl = spaceRoom.getAvatarUrl;
+    const accessToken = matrixClient?.getAccessToken?.();
+
+    const withAccessToken = (
+      url: string | null | undefined,
+    ): string | undefined => {
+      if (!url) {
+        return undefined;
+      }
+      if (!accessToken || !url.includes("/_matrix/")) {
+        return url;
+      }
+      if (url.includes("access_token=")) {
+        return url;
+      }
+      const separator = url.includes("?") ? "&" : "?";
+      return `${url}${separator}access_token=${encodeURIComponent(accessToken)}`;
+    };
+
+    if (homeserverUrl && typeof getAvatarUrl === "function") {
+      const httpAvatarUrl = getAvatarUrl.call(
+        spaceRoom,
+        homeserverUrl,
+        40,
+        40,
+        "crop",
+        false,
+        true,
+      ) as string | null;
+      if (httpAvatarUrl) {
+        return withAccessToken(httpAvatarUrl);
+      }
+    }
+
+    const avatarMxcFromRoom = spaceRoom.getMxcAvatarUrl?.();
+    const avatarStateEvent = spaceRoom.currentState?.getStateEvents?.(
+      "m.room.avatar",
+      "",
+    );
+    const avatarMxcUrl =
+      avatarMxcFromRoom || avatarStateEvent?.getContent?.()?.url;
+    if (!avatarMxcUrl || !matrixClient?.mxcUrlToHttp) {
+      return undefined;
+    }
+
+    try {
+      const httpUrl = matrixClient.mxcUrlToHttp(
+        avatarMxcUrl,
+        40,
+        40,
+        "crop",
+        false,
+        true,
+        true,
+      ) as string;
+      return withAccessToken(httpUrl);
+    } catch {
+      return undefined;
+    }
+  }
+
+  function getMemberAvatarUrl(member: Record<string, any>): string | undefined {
+    const matrixClient = client.value;
+    const homeserverUrl = matrixClient?.getHomeserverUrl?.();
+    const getAvatarUrl = member.getAvatarUrl;
+    if (homeserverUrl && typeof getAvatarUrl === "function") {
+      const avatarUrl = getAvatarUrl.call(
+        member,
+        homeserverUrl,
+        40,
+        40,
+        "crop",
+        false,
+        false,
+        true,
+      ) as string | null;
+      if (avatarUrl) {
+        return appendAccessTokenToMediaUrl(avatarUrl);
+      }
+    }
+
+    const avatarMxcUrl = member.events?.member?.getContent?.()?.avatar_url;
+    if (!avatarMxcUrl || !matrixClient?.mxcUrlToHttp) {
+      return undefined;
+    }
+    const avatarUrl = matrixClient.mxcUrlToHttp(
+      avatarMxcUrl,
+      40,
+      40,
+      "crop",
+      false,
+      true,
+      true,
+    );
+    return appendAccessTokenToMediaUrl(avatarUrl);
+  }
+
+  function getMediaUrl(
+    mxcUrl: string | null | undefined,
+    mimetype?: string,
+    body?: string,
+  ): string | undefined {
+    if (!mxcUrl || !client.value?.mxcUrlToHttp) {
+      return undefined;
+    }
+    try {
+      const httpUrl = client.value.mxcUrlToHttp(
+        mxcUrl,
+        800,
+        800,
+        "scale",
+        false,
+        true,
+        true,
+      );
+      return appendAccessTokenToMediaUrl(httpUrl);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function resolveMediaBlobUrl(media: MediaPayload): Promise<string> {
+    const matrixClient = client.value;
+    if (!matrixClient) {
+      throw new Error("No client available");
+    }
+
+    const accessToken = matrixClient.getAccessToken?.() ?? "";
+    const httpUrl = matrixClient.mxcUrlToHttp(
+      media.mxcUrl,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      true,
+      true,
+    );
+    if (!httpUrl) {
+      throw new Error("Could not resolve MXC URL");
+    }
+
+    if (media.isEncrypted && media.encryptionInfo) {
+      return decryptMediaBlob(
+        httpUrl,
+        accessToken,
+        media.encryptionInfo as any,
+        media.mimetype,
+      );
+    }
+    return fetchMediaBlob(httpUrl, accessToken);
+  }
+
+  return {
+    getSpaceAvatarUrl,
+    getMemberAvatarUrl,
+    getMediaUrl,
+    resolveMediaBlobUrl,
+  };
+}

--- a/app/composables/useEmojiPickerData.ts
+++ b/app/composables/useEmojiPickerData.ts
@@ -1,0 +1,647 @@
+export type EmojiCategoryId =
+  | "frequent"
+  | "smileys"
+  | "animals"
+  | "food"
+  | "activities"
+  | "travel"
+  | "objects"
+  | "symbols"
+  | "flags";
+
+export interface EmojiCategory {
+  id: EmojiCategoryId;
+  label: string;
+  icon: string;
+}
+
+export interface EmojiEntry {
+  emoji: string;
+  name: string;
+  shortcodes: string[];
+  keywords: string[];
+  category: Exclude<EmojiCategoryId, "frequent">;
+}
+
+const FREQUENT_EMOJI_STORAGE_KEY_PREFIX = "decentra.chat.frequent-emojis.v1";
+
+export const categoryOrder: EmojiCategory[] = [
+  { id: "frequent", label: "Häufig verwendet", icon: "🕘" },
+  { id: "smileys", label: "Smileys & Menschen", icon: "😀" },
+  { id: "animals", label: "Tiere & Natur", icon: "🐶" },
+  { id: "food", label: "Essen & Trinken", icon: "🍎" },
+  { id: "activities", label: "Aktivitäten", icon: "⚽" },
+  { id: "travel", label: "Reisen", icon: "🚗" },
+  { id: "objects", label: "Objekte", icon: "💡" },
+  { id: "symbols", label: "Symbole", icon: "❗" },
+  { id: "flags", label: "Flaggen", icon: "🏳️" },
+];
+
+export const defaultFrequentEmojis = [
+  "👍", "👎", "😂", "🎉", "😮", "❤️", "🚀", "👀",
+];
+
+function createEmojiEntry(input: EmojiEntry): EmojiEntry {
+  return input;
+}
+
+export const emojiCatalog: EmojiEntry[] = [
+  createEmojiEntry({
+    emoji: "😀", name: "grinning", shortcodes: ["grinning"],
+    keywords: ["face", "smile"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😃", name: "smiley", shortcodes: ["smiley"],
+    keywords: ["happy", "face"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😄", name: "smile", shortcodes: ["smile"],
+    keywords: ["joy", "face"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😁", name: "grin", shortcodes: ["grin"],
+    keywords: ["happy", "teeth"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😂", name: "joy", shortcodes: ["joy", "laughing"],
+    keywords: ["tears", "laugh"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🤣", name: "rofl", shortcodes: ["rofl"],
+    keywords: ["laugh"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😊", name: "blush", shortcodes: ["blush"],
+    keywords: ["happy", "smile"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😉", name: "wink", shortcodes: ["wink"],
+    keywords: ["face"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😍", name: "heart eyes", shortcodes: ["heart_eyes"],
+    keywords: ["love", "face"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😘", name: "kiss", shortcodes: ["kissing_heart"],
+    keywords: ["love"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😎", name: "sunglasses", shortcodes: ["sunglasses"],
+    keywords: ["cool"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😭", name: "sob", shortcodes: ["sob"],
+    keywords: ["sad"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😢", name: "cry", shortcodes: ["cry"],
+    keywords: ["sad"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😡", name: "angry", shortcodes: ["angry"],
+    keywords: ["mad"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🤔", name: "thinking", shortcodes: ["thinking", "thinking_face"],
+    keywords: ["hmm"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😮", name: "open mouth", shortcodes: ["open_mouth"],
+    keywords: ["surprised"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😴", name: "sleeping", shortcodes: ["sleeping"],
+    keywords: ["tired"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🤯", name: "mind blown", shortcodes: ["exploding_head"],
+    keywords: ["wow"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "😅", name: "sweat smile", shortcodes: ["sweat_smile"],
+    keywords: ["awkward"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🤗", name: "hugging", shortcodes: ["hugging_face"],
+    keywords: ["hug"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🫡", name: "saluting", shortcodes: ["saluting_face"],
+    keywords: ["respect"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🙏", name: "pray", shortcodes: ["pray"],
+    keywords: ["thanks"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "👋", name: "wave", shortcodes: ["wave"],
+    keywords: ["hello"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🫂",
+    name: "people hugging",
+    shortcodes: ["people_hugging", "hugging_people"],
+    keywords: ["hug", "support", "care"],
+    category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🤝", name: "handshake", shortcodes: ["handshake"],
+    keywords: ["deal"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "👏", name: "clap", shortcodes: ["clap"],
+    keywords: ["applause"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "👍",
+    name: "thumbs up",
+    shortcodes: ["thumbsup", "+1", "thumbs_up", "thumbs-up"],
+    keywords: ["like"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "👎",
+    name: "thumbs down",
+    shortcodes: ["thumbsdown", "-1", "thumbs_down", "thumbs-down"],
+    keywords: ["dislike"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🔥", name: "fire", shortcodes: ["fire"],
+    keywords: ["lit"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "💯", name: "100", shortcodes: ["100"],
+    keywords: ["perfect"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🤷", name: "shrug", shortcodes: ["shrug"],
+    keywords: ["idk"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🤦", name: "facepalm", shortcodes: ["facepalm"],
+    keywords: ["oops"], category: "smileys",
+  }),
+  createEmojiEntry({
+    emoji: "🐶", name: "dog", shortcodes: ["dog"], keywords: ["pet"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐱", name: "cat", shortcodes: ["cat"], keywords: ["pet"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐭", name: "mouse", shortcodes: ["mouse"], keywords: ["animal"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐹", name: "hamster", shortcodes: ["hamster"],
+    keywords: ["animal"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐰", name: "rabbit", shortcodes: ["rabbit"],
+    keywords: ["animal"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🦊", name: "fox", shortcodes: ["fox"], keywords: ["animal"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐻", name: "bear", shortcodes: ["bear"], keywords: ["animal"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐼", name: "panda", shortcodes: ["panda_face"],
+    keywords: ["animal"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐨", name: "koala", shortcodes: ["koala"],
+    keywords: ["animal"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐯", name: "tiger", shortcodes: ["tiger"], keywords: ["animal"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🦁", name: "lion", shortcodes: ["lion"], keywords: ["animal"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐷", name: "pig", shortcodes: ["pig"], keywords: ["animal"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐸", name: "frog", shortcodes: ["frog"], keywords: ["animal"],
+    category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🐵", name: "monkey", shortcodes: ["monkey_face"],
+    keywords: ["animal"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🦄", name: "unicorn", shortcodes: ["unicorn"],
+    keywords: ["animal"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🌱", name: "seedling", shortcodes: ["seedling"],
+    keywords: ["plant"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🌳", name: "tree", shortcodes: ["deciduous_tree"],
+    keywords: ["nature"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🌞", name: "sun", shortcodes: ["sun_with_face"],
+    keywords: ["weather"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🌧️", name: "rain cloud", shortcodes: ["cloud_with_rain"],
+    keywords: ["weather"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🌙", name: "moon", shortcodes: ["crescent_moon"],
+    keywords: ["night"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "⭐", name: "star", shortcodes: ["star"],
+    keywords: ["night"], category: "animals",
+  }),
+  createEmojiEntry({
+    emoji: "🍎", name: "apple", shortcodes: ["apple"], keywords: ["fruit"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍌", name: "banana", shortcodes: ["banana"], keywords: ["fruit"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍇", name: "grapes", shortcodes: ["grapes"], keywords: ["fruit"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍓", name: "strawberry", shortcodes: ["strawberry"],
+    keywords: ["fruit"], category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍕", name: "pizza", shortcodes: ["pizza"], keywords: ["food"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍔", name: "burger", shortcodes: ["hamburger"],
+    keywords: ["food"], category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍟", name: "fries", shortcodes: ["fries"], keywords: ["food"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🌮", name: "taco", shortcodes: ["taco"], keywords: ["food"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍣", name: "sushi", shortcodes: ["sushi"], keywords: ["food"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍜", name: "ramen", shortcodes: ["ramen"], keywords: ["food"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍰", name: "cake", shortcodes: ["cake"], keywords: ["dessert"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍪", name: "cookie", shortcodes: ["cookie"],
+    keywords: ["dessert"], category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "☕", name: "coffee", shortcodes: ["coffee"], keywords: ["drink"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🍺", name: "beer", shortcodes: ["beer"], keywords: ["drink"],
+    category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "🥤", name: "cup", shortcodes: ["cup_with_straw"],
+    keywords: ["drink"], category: "food",
+  }),
+  createEmojiEntry({
+    emoji: "⚽", name: "soccer", shortcodes: ["soccer"], keywords: ["sport"],
+    category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🏀", name: "basketball", shortcodes: ["basketball"],
+    keywords: ["sport"], category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🏈", name: "football", shortcodes: ["football"],
+    keywords: ["sport"], category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🎾", name: "tennis", shortcodes: ["tennis"], keywords: ["sport"],
+    category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🏓", name: "ping pong", shortcodes: ["ping_pong"],
+    keywords: ["sport"], category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🎮", name: "gamepad", shortcodes: ["video_game"],
+    keywords: ["gaming"], category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🧩", name: "puzzle", shortcodes: ["jigsaw"], keywords: ["game"],
+    category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🎵", name: "music", shortcodes: ["musical_note"],
+    keywords: ["song"], category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🎸", name: "guitar", shortcodes: ["guitar"], keywords: ["music"],
+    category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🎬", name: "clapper", shortcodes: ["clapper"],
+    keywords: ["movie"], category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🎉", name: "party", shortcodes: ["tada"],
+    keywords: ["celebration"], category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🏆", name: "trophy", shortcodes: ["trophy"], keywords: ["win"],
+    category: "activities",
+  }),
+  createEmojiEntry({
+    emoji: "🚗", name: "car", shortcodes: ["car"], keywords: ["travel"],
+    category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "🚕", name: "taxi", shortcodes: ["taxi"], keywords: ["travel"],
+    category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "🚌", name: "bus", shortcodes: ["bus"], keywords: ["travel"],
+    category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "🚲", name: "bike", shortcodes: ["bike"], keywords: ["travel"],
+    category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "🏍️", name: "motorcycle", shortcodes: ["motorcycle"],
+    keywords: ["travel"], category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "✈️", name: "airplane", shortcodes: ["airplane"],
+    keywords: ["flight"], category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "🛫", name: "takeoff", shortcodes: ["airplane_departure"],
+    keywords: ["flight"], category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "🚀", name: "rocket", shortcodes: ["rocket"],
+    keywords: ["launch"], category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "🏖️", name: "beach", shortcodes: ["beach_with_umbrella"],
+    keywords: ["vacation"], category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "🗺️", name: "map", shortcodes: ["world_map"],
+    keywords: ["travel"], category: "travel",
+  }),
+  createEmojiEntry({
+    emoji: "💡", name: "bulb", shortcodes: ["bulb"], keywords: ["idea"],
+    category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "📌", name: "pushpin", shortcodes: ["pushpin"],
+    keywords: ["mark"], category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "📎", name: "paperclip", shortcodes: ["paperclip"],
+    keywords: ["attach"], category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "📱", name: "phone", shortcodes: ["iphone"],
+    keywords: ["mobile"], category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "💻", name: "computer", shortcodes: ["computer"],
+    keywords: ["tech"], category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "⌚", name: "watch", shortcodes: ["watch"], keywords: ["time"],
+    category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "🔔", name: "bell", shortcodes: ["bell"], keywords: ["notify"],
+    category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "🔒", name: "lock", shortcodes: ["lock"], keywords: ["secure"],
+    category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "🔑", name: "key", shortcodes: ["key"], keywords: ["secure"],
+    category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "🧠", name: "brain", shortcodes: ["brain"], keywords: ["think"],
+    category: "objects",
+  }),
+  createEmojiEntry({
+    emoji: "❤️",
+    name: "heart",
+    shortcodes: ["heart", "red_heart"],
+    keywords: ["love"],
+    category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "🩷", name: "pink heart", shortcodes: ["pink_heart"],
+    keywords: ["love"], category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "💔", name: "broken heart", shortcodes: ["broken_heart"],
+    keywords: ["sad"], category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "✅", name: "check", shortcodes: ["white_check_mark"],
+    keywords: ["ok"], category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "❌", name: "x", shortcodes: ["x"], keywords: ["no"],
+    category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "❗", name: "exclamation", shortcodes: ["exclamation"],
+    keywords: ["important"], category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "❓", name: "question", shortcodes: ["question"],
+    keywords: ["help"], category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "⚠️", name: "warning", shortcodes: ["warning"],
+    keywords: ["alert"], category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "♻️", name: "recycle", shortcodes: ["recycle"],
+    keywords: ["green"], category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "✨", name: "sparkles", shortcodes: ["sparkles"],
+    keywords: ["magic"], category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "👀", name: "eyes", shortcodes: ["eyes"], keywords: ["look"],
+    category: "symbols",
+  }),
+  createEmojiEntry({
+    emoji: "🏳️", name: "white flag", shortcodes: ["white_flag"],
+    keywords: ["flag"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🏴", name: "black flag", shortcodes: ["black_flag"],
+    keywords: ["flag"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🏁", name: "chequered flag", shortcodes: ["checkered_flag"],
+    keywords: ["race"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🇩🇪", name: "germany", shortcodes: ["flag_de"],
+    keywords: ["flag"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🇪🇺", name: "eu", shortcodes: ["flag_eu"],
+    keywords: ["flag"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🇺🇸", name: "usa", shortcodes: ["flag_us"],
+    keywords: ["flag"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🇬🇧", name: "uk", shortcodes: ["flag_gb"],
+    keywords: ["flag"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🇫🇷", name: "france", shortcodes: ["flag_fr"],
+    keywords: ["flag"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🇪🇸", name: "spain", shortcodes: ["flag_es"],
+    keywords: ["flag"], category: "flags",
+  }),
+  createEmojiEntry({
+    emoji: "🇮🇹", name: "italy", shortcodes: ["flag_it"],
+    keywords: ["flag"], category: "flags",
+  }),
+];
+
+export function createShortcodeMap(entries: EmojiEntry[]): Map<string, string> {
+  const shortcodeToEmoji = new Map<string, string>();
+  for (const emojiEntry of entries) {
+    for (const shortcode of emojiEntry.shortcodes) {
+      const normalizedShortcode = shortcode.toLowerCase();
+      shortcodeToEmoji.set(normalizedShortcode, emojiEntry.emoji);
+      shortcodeToEmoji.set(
+        normalizedShortcode.replace(/-/g, "_"),
+        emojiEntry.emoji
+      );
+      shortcodeToEmoji.set(
+        normalizedShortcode.replace(/_/g, "-"),
+        emojiEntry.emoji
+      );
+      shortcodeToEmoji.set(
+        normalizedShortcode.replace(/[_-]/g, ""),
+        emojiEntry.emoji
+      );
+    }
+  }
+  return shortcodeToEmoji;
+}
+
+export function normalizeShortcodes(
+  rawValue: string,
+  shortcodeMap: Map<string, string>
+): string {
+  return rawValue.replace(/:([a-z0-9_+-]+):/gi, (matchText, shortcode) => {
+    const shortcodeEmoji = shortcodeMap.get(String(shortcode).toLowerCase());
+    return shortcodeEmoji ?? matchText;
+  });
+}
+
+function buildScopeStorageSuffix(scopeKey?: string): string {
+  if (!scopeKey || scopeKey.trim().length === 0) {
+    return "anonymous";
+  }
+  return scopeKey.trim().toLowerCase();
+}
+
+export function buildFrequentEmojiStorageKey(scopeKey?: string): string {
+  const scopeSuffix = buildScopeStorageSuffix(scopeKey);
+  return `${FREQUENT_EMOJI_STORAGE_KEY_PREFIX}.${scopeSuffix}`;
+}
+
+export function loadFrequentEmojiUsage(
+  scopeKey?: string
+): Record<string, number> {
+  if (typeof window === "undefined") {
+    return {};
+  }
+  const storageKey = buildFrequentEmojiStorageKey(scopeKey);
+  const rawValue = localStorage.getItem(storageKey);
+  if (!rawValue) {
+    return {};
+  }
+  try {
+    const parsedValue = JSON.parse(rawValue) as Record<string, number>;
+    return parsedValue && typeof parsedValue === "object" ? parsedValue : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveFrequentEmojiUsage(
+  usage: Record<string, number>,
+  scopeKey?: string
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const storageKey = buildFrequentEmojiStorageKey(scopeKey);
+  localStorage.setItem(storageKey, JSON.stringify(usage));
+}
+
+export function trackEmojiUsage(
+  usage: Record<string, number>,
+  emoji: string
+): Record<string, number> {
+  const nextUsage = { ...usage };
+  nextUsage[emoji] = (nextUsage[emoji] ?? 0) + 1;
+  return nextUsage;
+}
+
+export function getFrequentEmojis(
+  usage: Record<string, number>,
+  fallbackEmojis: string[],
+  limit = 12
+): string[] {
+  const byUsage = Object.entries(usage)
+    .sort((leftEntry, rightEntry) => rightEntry[1] - leftEntry[1])
+    .map(([emoji]) => emoji);
+  const merged: string[] = [];
+  for (const emoji of [...byUsage, ...fallbackEmojis]) {
+    if (!merged.includes(emoji)) {
+      merged.push(emoji);
+    }
+    if (merged.length >= limit) {
+      break;
+    }
+  }
+  return merged;
+}

--- a/app/composables/useMatrixClient.ts
+++ b/app/composables/useMatrixClient.ts
@@ -38,6 +38,10 @@ interface MessageReplyOptions {
   eventId: string
 }
 
+interface ReactionToggleOptions {
+  ownReactionEventIds?: string[]
+}
+
 function extractUserLocalpart(userIdOrUsername: string): string {
   const normalized = userIdOrUsername.trim().toLowerCase()
   const withoutAtPrefix = normalized.startsWith('@')
@@ -533,6 +537,59 @@ export function useMatrixClient() {
     return client.value.paginateEventTimeline(timeline, { backwards: true })
   }
 
+  async function sendReaction(
+    roomId: string,
+    eventId: string,
+    emoji: string
+  ): Promise<void> {
+    if (!client.value) {
+      throw new Error('Not logged in')
+    }
+    const trimmedEmoji = emoji.trim()
+    if (!trimmedEmoji) {
+      throw new Error('Emoji is required')
+    }
+    await client.value.sendEvent(roomId, 'm.reaction' as any, {
+      'm.relates_to': {
+        rel_type: 'm.annotation',
+        event_id: eventId,
+        key: trimmedEmoji
+      }
+    } as any)
+  }
+
+  async function redactEvent(
+    roomId: string,
+    reactionEventId: string
+  ): Promise<void> {
+    if (!client.value) {
+      throw new Error('Not logged in')
+    }
+    await (client.value as MatrixClient & {
+      redactEvent: (
+        roomId: string,
+        eventId: string
+      ) => Promise<unknown>
+    }).redactEvent(roomId, reactionEventId)
+  }
+
+  async function toggleReaction(
+    roomId: string,
+    messageEventId: string,
+    emoji: string,
+    options?: ReactionToggleOptions | string[]
+  ): Promise<void> {
+    const ownReactionEventIds = Array.isArray(options)
+      ? options
+      : options?.ownReactionEventIds ?? []
+    const firstOwnReactionEventId = ownReactionEventIds[0]
+    if (firstOwnReactionEventId) {
+      await redactEvent(roomId, firstOwnReactionEventId)
+      return
+    }
+    await sendReaction(roomId, messageEventId, emoji)
+  }
+
   return {
     client,
     isLoggedIn,
@@ -543,6 +600,9 @@ export function useMatrixClient() {
     getRoom,
     sendMessage,
     sendImageMessage,
+    sendReaction,
+    redactEvent,
+    toggleReaction,
     loadOlderMessages,
     ensureCryptoReady
   }

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { ClientEvent, MatrixEventEvent, RoomEvent } from "matrix-js-sdk";
 import { useAppI18n } from "~/composables/useAppI18n";
-import { mapTimelineEventsToMessages } from "~/utils/chatTimeline";
-import { fetchMediaBlob, decryptMediaBlob } from "~/utils/mediaUtils";
+import { useChatMedia } from "~/composables/useChatMedia";
+import {
+  buildReactionSummaryByEventId,
+  mapTimelineEventsToMessages,
+} from "~/utils/chatTimeline";
 
 type PresenceStatus = "online" | "away" | "busy" | "offline" | "unknown";
 
@@ -19,6 +22,24 @@ interface ChatMessage {
     senderName: string;
     body: string;
   };
+  media?: {
+    url: string;
+    mxcUrl: string;
+    mimetype?: string;
+    isEncrypted?: boolean;
+    encryptionInfo?: Record<string, any>;
+    info?: {
+      w?: number;
+      h?: number;
+      size?: number;
+    };
+  };
+  reactions: Array<{
+    emoji: string;
+    count: number;
+    hasOwnReaction: boolean;
+    ownReactionEventIds: string[];
+  }>;
   readBy: Array<{
     userId: string;
     displayName: string;
@@ -60,9 +81,22 @@ interface MemberItem {
 const MOBILE_BREAKPOINT = 1024;
 const HOME_SPACE_ID = "__home__";
 
-const { client, isLoggedIn, userId, getRooms, logout, loadOlderMessages } =
-  useMatrixClient();
+const {
+  client,
+  isLoggedIn,
+  userId,
+  getRooms,
+  logout,
+  loadOlderMessages,
+  toggleReaction,
+} = useMatrixClient();
 const { translateText } = useAppI18n();
+const {
+  getSpaceAvatarUrl,
+  getMemberAvatarUrl,
+  getMediaUrl,
+  resolveMediaBlobUrl,
+} = useChatMedia(client as any);
 
 const selectedRoomId = ref<string | null>(null);
 const selectedSpaceId = ref<string | null>(null);
@@ -359,184 +393,6 @@ function isDirectRoom(room: RoomItem): boolean {
   return room.parentSpaceIds.length === 0 && joinedMemberCount === 2;
 }
 
-function getSpaceAvatarUrl(spaceRoom: Record<string, any>): string | undefined {
-  const matrixClient = client.value;
-  const homeserverUrl = matrixClient?.getHomeserverUrl?.();
-  const getAvatarUrl = spaceRoom.getAvatarUrl;
-  const accessToken = matrixClient?.getAccessToken?.();
-
-  const withAccessToken = (
-    url: string | null | undefined,
-  ): string | undefined => {
-    if (!url) {
-      return undefined;
-    }
-    if (!accessToken || !url.includes("/_matrix/")) {
-      return url;
-    }
-    if (url.includes("access_token=")) {
-      return url;
-    }
-    const separator = url.includes("?") ? "&" : "?";
-    return `${url}${separator}access_token=${encodeURIComponent(accessToken)}`;
-  };
-
-  if (homeserverUrl && typeof getAvatarUrl === "function") {
-    const httpAvatarUrl = getAvatarUrl.call(
-      spaceRoom,
-      homeserverUrl,
-      40,
-      40,
-      "crop",
-      false,
-      true,
-    ) as string | null;
-    if (httpAvatarUrl) {
-      return withAccessToken(httpAvatarUrl);
-    }
-  }
-
-  const avatarMxcFromRoom = spaceRoom.getMxcAvatarUrl?.();
-  const avatarStateEvent = spaceRoom.currentState?.getStateEvents?.(
-    "m.room.avatar",
-    "",
-  );
-  const avatarMxcUrl =
-    avatarMxcFromRoom || avatarStateEvent?.getContent?.()?.url;
-  if (!avatarMxcUrl || !matrixClient?.mxcUrlToHttp) {
-    return undefined;
-  }
-
-  try {
-    const httpUrl = matrixClient.mxcUrlToHttp(
-      avatarMxcUrl,
-      40,
-      40,
-      "crop",
-      false,
-      true,
-      true,
-    ) as string;
-    return withAccessToken(httpUrl);
-  } catch {
-    return undefined;
-  }
-}
-
-function getMemberAvatarUrl(member: Record<string, any>): string | undefined {
-  const matrixClient = client.value;
-  const homeserverUrl = matrixClient?.getHomeserverUrl?.();
-  const getAvatarUrl = member.getAvatarUrl;
-  if (homeserverUrl && typeof getAvatarUrl === "function") {
-    const avatarUrl = getAvatarUrl.call(
-      member,
-      homeserverUrl,
-      40,
-      40,
-      "crop",
-      false,
-      false,
-      true,
-    ) as string | null;
-    if (avatarUrl) {
-      return appendAccessTokenToMediaUrl(avatarUrl);
-    }
-  }
-
-  const avatarMxcUrl = member.events?.member?.getContent?.()?.avatar_url;
-  if (!avatarMxcUrl || !matrixClient?.mxcUrlToHttp) {
-    return undefined;
-  }
-  const avatarUrl = matrixClient.mxcUrlToHttp(
-    avatarMxcUrl,
-    40,
-    40,
-    "crop",
-    false,
-    true,
-    true,
-  );
-  return appendAccessTokenToMediaUrl(avatarUrl);
-}
-
-function getMediaUrl(
-  mxcUrl: string | null | undefined,
-  mimetype?: string,
-  body?: string,
-): string | undefined {
-  if (!mxcUrl || !client.value?.mxcUrlToHttp) {
-    return undefined;
-  }
-  try {
-    const httpUrl = client.value.mxcUrlToHttp(
-      mxcUrl,
-      800,
-      800,
-      "scale",
-      false,
-      true,
-      true,
-    );
-    return appendAccessTokenToMediaUrl(httpUrl);
-  } catch {
-    return undefined;
-  }
-}
-
-async function resolveMediaBlobUrl(media: {
-  mxcUrl: string;
-  mimetype?: string;
-  isEncrypted?: boolean;
-  encryptionInfo?: Record<string, any>;
-}): Promise<string> {
-  const matrixClient = client.value;
-  if (!matrixClient) {
-    throw new Error("No client available");
-  }
-
-  const accessToken = matrixClient.getAccessToken?.() ?? "";
-  const httpUrl = matrixClient.mxcUrlToHttp(
-    media.mxcUrl,
-    undefined,
-    undefined,
-    undefined,
-    false,
-    true,
-    true,
-  );
-  if (!httpUrl) {
-    throw new Error("Could not resolve MXC URL");
-  }
-
-  if (media.isEncrypted && media.encryptionInfo) {
-    return decryptMediaBlob(
-      httpUrl,
-      accessToken,
-      media.encryptionInfo as any,
-      media.mimetype,
-    );
-  }
-  return fetchMediaBlob(httpUrl, accessToken);
-}
-
-function appendAccessTokenToMediaUrl(
-  avatarUrl: string | null | undefined,
-): string | undefined {
-  if (!avatarUrl) {
-    return undefined;
-  }
-  const matrixClient = client.value;
-  const accessToken = matrixClient?.getAccessToken?.();
-  if (!accessToken || !avatarUrl.includes("/_matrix/")) {
-    return avatarUrl;
-  }
-  if (avatarUrl.includes("access_token=")) {
-    return avatarUrl;
-  }
-  const separator = avatarUrl.includes("?") ? "&" : "?";
-  return `${avatarUrl}${separator}access_token=${encodeURIComponent(accessToken)}`;
-}
-
 function loadMessages(roomId: string) {
   const room = client.value?.getRoom(roomId);
   if (!room) {
@@ -552,6 +408,47 @@ function loadMessages(roomId: string) {
     getMediaUrl,
     buildNoticeText,
   });
+}
+
+function patchMessageReactions(roomId: string) {
+  const room = client.value?.getRoom(roomId);
+  if (!room) {
+    return;
+  }
+  const reactionSummaryByEventId = buildReactionSummaryByEventId(
+    room.getLiveTimeline().getEvents(),
+    client.value?.getUserId() ?? undefined,
+  );
+  messages.value = messages.value.map((message) => {
+    if (message.kind !== "message") {
+      return message;
+    }
+    return {
+      ...message,
+      reactions: reactionSummaryByEventId.get(message.id) ?? [],
+    };
+  });
+}
+
+function isReactionRelatedEvent(eventType: string): boolean {
+  return eventType === "m.reaction" || eventType === "m.room.redaction";
+}
+
+async function onToggleReaction(payload: {
+  messageId: string;
+  emoji: string;
+  ownReactionEventIds: string[];
+}) {
+  const activeRoomId = selectedRoomId.value;
+  if (!activeRoomId) {
+    return;
+  }
+  await toggleReaction(
+    activeRoomId,
+    payload.messageId,
+    payload.emoji,
+    payload.ownReactionEventIds,
+  );
 }
 
 function scheduleLoadMessages(roomId: string) {
@@ -730,10 +627,15 @@ watch(
       }
     });
     const timelineHandler = (
-      _event: unknown,
+      timelineEvent: Record<string, any> | undefined,
       room: Record<string, any> | undefined,
     ) => {
       if (room?.roomId === selectedRoomId.value) {
+        const eventType = timelineEvent?.getType?.() ?? "";
+        if (isReactionRelatedEvent(eventType)) {
+          patchMessageReactions(room.roomId);
+          return;
+        }
         scheduleLoadMessages(room.roomId);
       }
     };
@@ -745,6 +647,11 @@ watch(
         event?.getRoomId?.() === selectedRoomId.value &&
         selectedRoomId.value
       ) {
+        const eventType = event?.getType?.() ?? "";
+        if (isReactionRelatedEvent(eventType)) {
+          patchMessageReactions(selectedRoomId.value);
+          return;
+        }
         scheduleLoadMessages(selectedRoomId.value);
       }
     };
@@ -871,6 +778,7 @@ watch(
           :resolve-media-blob-url="resolveMediaBlobUrl"
           @load-older="onLoadOlder"
           @reply="setReplyTarget"
+          @toggle-reaction="onToggleReaction"
         />
         <ChatMessageInput
           :room-id="selectedRoomId"

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -773,6 +773,7 @@ watch(
       <template v-else>
         <ChatMessageList
           :messages="messages"
+          :current-user-id="userId ?? undefined"
           :can-load-older="canLoadOlder"
           :loading-older="loadingOlder"
           :resolve-media-blob-url="resolveMediaBlobUrl"

--- a/app/utils/chatTimeline.ts
+++ b/app/utils/chatTimeline.ts
@@ -21,11 +21,19 @@ export interface ChatTimelineMessage {
   body: string
   replyTo?: ChatTimelineReply
   media?: ChatTimelineMedia
+  reactions: ChatTimelineReaction[]
   readBy: Array<{
     userId: string
     displayName: string
     avatarUrl?: string
   }>
+}
+
+export interface ChatTimelineReaction {
+  emoji: string
+  count: number
+  hasOwnReaction: boolean
+  ownReactionEventIds: string[]
 }
 
 export interface ChatTimelineReply {
@@ -52,6 +60,11 @@ export function mapTimelineEventsToMessages({
   getMediaUrl,
   buildNoticeText
 }: MapTimelineArgs): ChatTimelineMessage[] {
+  const allTimelineEvents = room.getLiveTimeline().getEvents()
+  const reactionSummaryByEventId = buildReactionSummaryByEventId(
+    allTimelineEvents,
+    ownUserId
+  )
   const timelineEvents = room
     .getLiveTimeline()
     .getEvents()
@@ -137,6 +150,9 @@ export function mapTimelineEventsToMessages({
         : []
 
       const content = timelineEvent.getContent() ?? {}
+      const reactions = eventType === 'm.room.message' && currentEventId
+        ? reactionSummaryByEventId.get(currentEventId) ?? []
+        : []
       const mxcUrl = content.url || content.file?.url
       const isEncryptedMedia = Boolean(content.file?.url)
       const mimetype = content.info?.mimetype
@@ -174,6 +190,7 @@ export function mapTimelineEventsToMessages({
         body,
         replyTo,
         media,
+        reactions,
         readBy
       }
     } catch {
@@ -188,10 +205,76 @@ export function mapTimelineEventsToMessages({
         senderName,
         avatarUrl: senderMember ? getMemberAvatarUrl(senderMember) : undefined,
         body: buildUndecryptableMessageText(senderName),
+        reactions: [],
         readBy: []
       }
     }
   })
+}
+
+type TimelineEventRecord = Record<string, any>
+
+interface ReactionAggregate {
+  users: Set<string>
+  ownReactionEventIds: Set<string>
+}
+
+export function buildReactionSummaryByEventId(
+  timelineEvents: TimelineEventRecord[],
+  ownUserId: string | undefined
+): Map<string, ChatTimelineReaction[]> {
+  const redactedEventIds = getRedactedEventIds(timelineEvents)
+  const aggregatesByTargetEventId = new Map<string, Map<string, ReactionAggregate>>()
+
+  for (const timelineEvent of timelineEvents) {
+    const eventType = timelineEvent.getType?.() ?? ''
+    if (eventType !== 'm.reaction') {
+      continue
+    }
+    const reactionEventId = timelineEvent.getId?.()
+    if (!reactionEventId || redactedEventIds.has(reactionEventId)) {
+      continue
+    }
+    const reactionData = getReactionData(timelineEvent.getContent?.() ?? {})
+    if (!reactionData) {
+      continue
+    }
+    const senderUserId = timelineEvent.getSender?.() ?? ''
+    if (!senderUserId) {
+      continue
+    }
+
+    const byEmoji = getOrCreate(aggregatesByTargetEventId, reactionData.targetEventId, () => {
+      return new Map<string, ReactionAggregate>()
+    })
+    const aggregate = getOrCreate(byEmoji, reactionData.emoji, () => {
+      return {
+        users: new Set<string>(),
+        ownReactionEventIds: new Set<string>()
+      }
+    })
+    aggregate.users.add(senderUserId)
+    if (ownUserId && senderUserId === ownUserId) {
+      aggregate.ownReactionEventIds.add(reactionEventId)
+    }
+  }
+
+  const summaryByEventId = new Map<string, ChatTimelineReaction[]>()
+  for (const [targetEventId, byEmoji] of aggregatesByTargetEventId) {
+    const reactions = Array.from(byEmoji.entries())
+      .map(([emoji, aggregate]) => ({
+        emoji,
+        count: aggregate.users.size,
+        hasOwnReaction: aggregate.ownReactionEventIds.size > 0,
+        ownReactionEventIds: Array.from(aggregate.ownReactionEventIds)
+      }))
+      .sort((leftReaction, rightReaction) => {
+        return rightReaction.count - leftReaction.count ||
+          leftReaction.emoji.localeCompare(rightReaction.emoji)
+      })
+    summaryByEventId.set(targetEventId, reactions)
+  }
+  return summaryByEventId
 }
 
 export function isUndecryptableEvent(
@@ -268,4 +351,57 @@ function getReplyEventId(content: Record<string, any>): string | undefined {
   return typeof replyEventId === 'string' && replyEventId.length > 0
     ? replyEventId
     : undefined
+}
+
+function getRedactedEventIds(timelineEvents: TimelineEventRecord[]): Set<string> {
+  const redactedEventIds = new Set<string>()
+  for (const timelineEvent of timelineEvents) {
+    const eventType = timelineEvent.getType?.() ?? ''
+    if (eventType !== 'm.room.redaction') {
+      continue
+    }
+    const redactedEventId = timelineEvent.getRedacts?.() ??
+      timelineEvent.getContent?.()?.redacts ??
+      timelineEvent.event?.redacts
+    if (typeof redactedEventId === 'string' && redactedEventId.length > 0) {
+      redactedEventIds.add(redactedEventId)
+    }
+  }
+  return redactedEventIds
+}
+
+function getReactionData(
+  content: Record<string, any>
+): { targetEventId: string; emoji: string } | undefined {
+  const relatesTo = content['m.relates_to']
+  if (!relatesTo || typeof relatesTo !== 'object') {
+    return undefined
+  }
+  const relationType = relatesTo.rel_type
+  const targetEventId = relatesTo.event_id
+  const emoji = relatesTo.key
+  if (relationType !== 'm.annotation') {
+    return undefined
+  }
+  if (typeof targetEventId !== 'string' || targetEventId.length === 0) {
+    return undefined
+  }
+  if (typeof emoji !== 'string' || emoji.length === 0) {
+    return undefined
+  }
+  return { targetEventId, emoji }
+}
+
+function getOrCreate<TKey, TValue>(
+  inputMap: Map<TKey, TValue>,
+  key: TKey,
+  create: () => TValue
+): TValue {
+  const existingValue = inputMap.get(key)
+  if (existingValue !== undefined) {
+    return existingValue
+  }
+  const newValue = create()
+  inputMap.set(key, newValue)
+  return newValue
 }

--- a/tests/e2e/features/chat.feature
+++ b/tests/e2e/features/chat.feature
@@ -45,6 +45,15 @@ Feature: Chat
     And I should see a rendered reply for "E2E_REPLY_TO_VALID_EVENT"
     And I should see a missing-origin reply fallback
 
+  Scenario: Add and remove message reaction
+    When I open the login page
+    And I sign in with configured credentials
+    And I open the seeded test room
+    And I add reaction "👍" on message body "E2E_SEED_BASE_MESSAGE"
+    Then I should see reaction "👍" with count "1" on message body "E2E_SEED_BASE_MESSAGE"
+    When I remove reaction "👍" on message body "E2E_SEED_BASE_MESSAGE"
+    Then I should not see reaction "👍" on message body "E2E_SEED_BASE_MESSAGE"
+
   Scenario Outline: Member presence indicator reflects standard status
     When I open the login page
     And I sign in with configured credentials

--- a/tests/e2e/step-definitions/chat.steps.mjs
+++ b/tests/e2e/step-definitions/chat.steps.mjs
@@ -42,6 +42,12 @@ function currentUserNameNeedle() {
   return configuredUserId.split(':')[0]?.replace('@', '') || configuredUserId
 }
 
+function messageContainerByBody(page, messageText) {
+  return page.locator('div.group').filter({
+    hasText: messageText
+  }).first()
+}
+
 When('I open the chat page', async function () {
   await this.page.goto(`${BASE_URL}/chat`)
 })
@@ -130,9 +136,7 @@ Then('I should see image fallback label {string}', async function (fallbackLabel
 })
 
 When('I click reply on message body {string}', async function (messageText) {
-  const messageItem = this.page.locator('div.group').filter({
-    hasText: messageText
-  }).first()
+  const messageItem = messageContainerByBody(this.page, messageText)
   await expect(messageItem).toBeVisible({ timeout: 15000 })
   await messageItem.hover()
   const replyButton = messageItem
@@ -141,6 +145,66 @@ When('I click reply on message body {string}', async function (messageText) {
   await expect(replyButton).toBeVisible({ timeout: 10000 })
   await replyButton.click()
 })
+
+When(
+  'I add reaction {string} on message body {string}',
+  async function (emoji, messageText) {
+    const messageItem = messageContainerByBody(this.page, messageText)
+    await expect(messageItem).toBeVisible({ timeout: 15000 })
+    await messageItem.hover()
+
+    const reactionButton = messageItem.getByRole('button', {
+      name: /Add reaction/i
+    }).first()
+    await expect(reactionButton).toBeVisible({ timeout: 10000 })
+    await reactionButton.click()
+
+    const emojiOption = this.page
+      .locator(`[data-emoji-option="${emoji}"]`)
+      .first()
+    await expect(emojiOption).toBeVisible({ timeout: 10000 })
+    await emojiOption.click()
+  }
+)
+
+When(
+  'I remove reaction {string} on message body {string}',
+  async function (emoji, messageText) {
+    const messageItem = messageContainerByBody(this.page, messageText)
+    await expect(messageItem).toBeVisible({ timeout: 15000 })
+    const reactionChip = messageItem
+      .locator(`[data-reaction-chip="${emoji}"]`)
+      .first()
+    await expect(reactionChip).toBeVisible({ timeout: 10000 })
+    await reactionChip.click()
+  }
+)
+
+Then(
+  'I should see reaction {string} with count {string} on message body {string}',
+  async function (emoji, count, messageText) {
+    const messageItem = messageContainerByBody(this.page, messageText)
+    await expect(messageItem).toBeVisible({ timeout: 15000 })
+    const reactionChip = messageItem
+      .locator(`[data-reaction-chip="${emoji}"]`)
+      .first()
+    await expect(reactionChip).toBeVisible({ timeout: 10000 })
+    await expect(reactionChip).toContainText(emoji)
+    await expect(reactionChip).toContainText(count)
+  }
+)
+
+Then(
+  'I should not see reaction {string} on message body {string}',
+  async function (emoji, messageText) {
+    const messageItem = messageContainerByBody(this.page, messageText)
+    await expect(messageItem).toBeVisible({ timeout: 15000 })
+    const reactionChip = messageItem
+      .locator(`[data-reaction-chip="${emoji}"]`)
+      .first()
+    await expect(reactionChip).toHaveCount(0)
+  }
+)
 
 Then(
   'I should see the reply composer with preview {string}',

--- a/tests/unit/components/Chat/MessageItem.spec.ts
+++ b/tests/unit/components/Chat/MessageItem.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ChatMessageItem from '~/components/Chat/MessageItem.vue'
+
+const ChatMessageActionBarStub = {
+  emits: ['reply', 'reaction-pick'],
+  template: `
+    <div>
+      <button class="action-bar-reply" @click="$emit('reply')">Reply</button>
+      <button
+        class="action-bar-reaction"
+        @click="$emit('reaction-pick', '👍')"
+      >
+        React
+      </button>
+    </div>
+  `
+}
+
+function createMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'evt-message',
+    kind: 'message',
+    senderId: '@alice:example.org',
+    senderName: 'Alice',
+    body: 'Hello world',
+    reactions: [],
+    ...overrides
+  }
+}
+
+describe('MessageItem', () => {
+  it('renders reaction chips with count and own-state class', () => {
+    const wrapper = mount(ChatMessageItem, {
+      props: {
+        message: createMessage({
+          reactions: [
+            {
+              emoji: '👍',
+              count: 2,
+              hasOwnReaction: true,
+              ownReactionEventIds: ['reaction-1']
+            },
+            {
+              emoji: '🔥',
+              count: 1,
+              hasOwnReaction: false,
+              ownReactionEventIds: []
+            }
+          ]
+        })
+      },
+      global: {
+        stubs: {
+          ChatMessageActionBar: ChatMessageActionBarStub
+        }
+      }
+    })
+
+    const chips = wrapper.findAll('[data-reaction-chip]')
+    chips.length.should.equal(2)
+    chips[0]!.text().should.include('👍')
+    chips[0]!.text().should.include('2')
+    chips[0]!.classes().should.include('bg-blue-50')
+  })
+
+  it('emits toggleReaction when clicking existing reaction chip', async () => {
+    const wrapper = mount(ChatMessageItem, {
+      props: {
+        message: createMessage({
+          reactions: [
+            {
+              emoji: '👍',
+              count: 1,
+              hasOwnReaction: true,
+              ownReactionEventIds: ['reaction-own']
+            }
+          ]
+        })
+      },
+      global: {
+        stubs: {
+          ChatMessageActionBar: ChatMessageActionBarStub
+        }
+      }
+    })
+
+    await wrapper.find('[data-reaction-chip="👍"]').trigger('click')
+    const emittedEvents = wrapper.emitted('toggleReaction') ?? []
+    emittedEvents.length.should.equal(1)
+    const payload = emittedEvents[0]![0] as Record<string, any>
+    payload.messageId.should.equal('evt-message')
+    payload.emoji.should.equal('👍')
+    payload.ownReactionEventIds[0].should.equal('reaction-own')
+  })
+
+  it('emits toggleReaction when picker emits reaction-pick', async () => {
+    const wrapper = mount(ChatMessageItem, {
+      props: {
+        message: createMessage()
+      },
+      global: {
+        stubs: {
+          ChatMessageActionBar: ChatMessageActionBarStub
+        }
+      }
+    })
+
+    await wrapper.find('.action-bar-reaction').trigger('click')
+    const emittedEvents = wrapper.emitted('toggleReaction') ?? []
+    emittedEvents.length.should.equal(1)
+    const payload = emittedEvents[0]![0] as Record<string, any>
+    payload.emoji.should.equal('👍')
+    payload.ownReactionEventIds.length.should.equal(0)
+  })
+})

--- a/tests/unit/components/Chat/ReactionEmojiPicker.spec.ts
+++ b/tests/unit/components/Chat/ReactionEmojiPicker.spec.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import ChatReactionEmojiPicker from "~/components/Chat/ReactionEmojiPicker.vue";
+import { buildFrequentEmojiStorageKey } from "~/composables/useEmojiPickerData";
+
+describe("ReactionEmojiPicker", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("emits selected emoji when clicking an emoji option", async () => {
+    const wrapper = mount(ChatReactionEmojiPicker);
+    const firstEmojiButton = wrapper.find('[data-emoji-option="👍"]');
+    await firstEmojiButton.trigger("click");
+
+    const emittedEvents = wrapper.emitted("select") ?? [];
+    expect(emittedEvents.length).toBe(1);
+    expect(emittedEvents[0]?.[0]).toBe("👍");
+  });
+
+  it("converts shortcode input before emit", async () => {
+    const wrapper = mount(ChatReactionEmojiPicker);
+    const input = wrapper.find('input[placeholder="Any emoji or :wave:"]');
+    await input.setValue(":wave:");
+    await input.trigger("keydown.enter");
+
+    const emittedEvents = wrapper.emitted("select") ?? [];
+    expect(emittedEvents.length).toBe(1);
+    expect(emittedEvents[0]?.[0]).toBe("👋");
+  });
+
+  it("supports :people_hugging: shortcode", async () => {
+    const wrapper = mount(ChatReactionEmojiPicker);
+    const input = wrapper.find('input[placeholder="Any emoji or :wave:"]');
+    await input.setValue(":people_hugging:");
+    await input.trigger("keydown.enter");
+
+    const emittedEvents = wrapper.emitted("select") ?? [];
+    expect(emittedEvents.length).toBe(1);
+    expect(emittedEvents[0]?.[0]).toBe("🫂");
+  });
+
+  it("persists frequent usage in localStorage", async () => {
+    const wrapper = mount(ChatReactionEmojiPicker, {
+      props: {
+        frequentScopeKey: "@alice:example.org",
+      },
+    });
+    await wrapper.find('[data-emoji-option="👍"]').trigger("click");
+    await wrapper.find('[data-emoji-option="👍"]').trigger("click");
+    await wrapper.find('[data-emoji-option="👍"]').trigger("click");
+
+    const storageKey = buildFrequentEmojiStorageKey("@alice:example.org");
+    const storedValue = localStorage.getItem(storageKey);
+    const parsedValue = storedValue
+      ? (JSON.parse(storedValue) as Record<string, number>)
+      : {};
+    expect(parsedValue["👍"]).toBe(3);
+  });
+});

--- a/tests/unit/composables/useMatrixClient.spec.ts
+++ b/tests/unit/composables/useMatrixClient.spec.ts
@@ -308,6 +308,78 @@ describe('useMatrixClient', () => {
     ;(globalThis as Record<string, unknown>).Image = originalImage
   })
 
+  it('sends reaction event payload', async () => {
+    const authClient = {
+      loginRequest: vi.fn(async () => ({
+        access_token: 'token-123',
+        user_id: '@alice:example.org',
+        device_id: 'DEVICE123'
+      }))
+    }
+    const matrixClient = {
+      initRustCrypto: vi.fn(async () => undefined),
+      startClient: vi.fn(),
+      sendEvent: vi.fn(async () => undefined)
+    }
+    createClient
+      .mockReturnValueOnce(authClient)
+      .mockReturnValueOnce(matrixClient)
+
+    const { useMatrixClient } = await import('~/composables/useMatrixClient')
+    const { login, sendReaction } = useMatrixClient()
+    await login('https://matrix.example.org', 'alice', 'secret')
+
+    await sendReaction('!room:example.org', 'evt-message', '👍')
+
+    expect(matrixClient.sendEvent).toHaveBeenCalledWith(
+      '!room:example.org',
+      'm.reaction',
+      expect.objectContaining({
+        'm.relates_to': {
+          rel_type: 'm.annotation',
+          event_id: 'evt-message',
+          key: '👍'
+        }
+      })
+    )
+  })
+
+  it('toggles reaction by redacting existing own reaction', async () => {
+    const authClient = {
+      loginRequest: vi.fn(async () => ({
+        access_token: 'token-123',
+        user_id: '@alice:example.org',
+        device_id: 'DEVICE123'
+      }))
+    }
+    const matrixClient = {
+      initRustCrypto: vi.fn(async () => undefined),
+      startClient: vi.fn(),
+      sendEvent: vi.fn(async () => undefined),
+      redactEvent: vi.fn(async () => undefined)
+    }
+    createClient
+      .mockReturnValueOnce(authClient)
+      .mockReturnValueOnce(matrixClient)
+
+    const { useMatrixClient } = await import('~/composables/useMatrixClient')
+    const { login, toggleReaction } = useMatrixClient()
+    await login('https://matrix.example.org', 'alice', 'secret')
+
+    await toggleReaction(
+      '!room:example.org',
+      'evt-message',
+      '👍',
+      ['reaction-own']
+    )
+
+    expect(matrixClient.redactEvent).toHaveBeenCalledWith(
+      '!room:example.org',
+      'reaction-own'
+    )
+    expect(matrixClient.sendEvent).not.toHaveBeenCalled()
+  })
+
   it('sends image message with encrypted file payload for E2EE room', async () => {
     const authClient = {
       loginRequest: vi.fn(async () => ({

--- a/tests/unit/utils/chatTimeline.spec.ts
+++ b/tests/unit/utils/chatTimeline.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'vitest'
 import {
+  buildReactionSummaryByEventId,
   buildUndecryptableMessageText,
   getMessageBody,
   isUndecryptableEvent,
@@ -259,5 +260,130 @@ describe('chatTimeline helpers', () => {
     messages[0]!.replyTo!.eventId.should.equal('evt_not_found')
     messages[0]!.replyTo!.senderName.should.equal('Unknown user')
     messages[0]!.replyTo!.body.should.equal('Original message unavailable.')
+  })
+
+  it('aggregates reactions by emoji and own user', () => {
+    const timelineEvents = [
+      {
+        getType: () => 'm.reaction',
+        getId: () => 'reaction-1',
+        getSender: () => '@alice:example.org',
+        getContent: () => ({
+          'm.relates_to': {
+            rel_type: 'm.annotation',
+            event_id: 'evt-message',
+            key: '👍'
+          }
+        })
+      },
+      {
+        getType: () => 'm.reaction',
+        getId: () => 'reaction-2',
+        getSender: () => '@bob:example.org',
+        getContent: () => ({
+          'm.relates_to': {
+            rel_type: 'm.annotation',
+            event_id: 'evt-message',
+            key: '👍'
+          }
+        })
+      },
+      {
+        getType: () => 'm.reaction',
+        getId: () => 'reaction-3',
+        getSender: () => '@alice:example.org',
+        getContent: () => ({
+          'm.relates_to': {
+            rel_type: 'm.annotation',
+            event_id: 'evt-message',
+            key: '🎉'
+          }
+        })
+      }
+    ]
+
+    const summary = buildReactionSummaryByEventId(
+      timelineEvents as any,
+      '@alice:example.org'
+    )
+
+    const messageReactions = summary.get('evt-message')!
+    messageReactions.length.should.equal(2)
+    messageReactions[0]!.emoji.should.equal('👍')
+    messageReactions[0]!.count.should.equal(2)
+    messageReactions[0]!.hasOwnReaction.should.equal(true)
+    messageReactions[1]!.emoji.should.equal('🎉')
+  })
+
+  it('drops redacted reactions from aggregation', () => {
+    const timelineEvents = [
+      {
+        getType: () => 'm.reaction',
+        getId: () => 'reaction-redacted',
+        getSender: () => '@alice:example.org',
+        getContent: () => ({
+          'm.relates_to': {
+            rel_type: 'm.annotation',
+            event_id: 'evt-message',
+            key: '👍'
+          }
+        })
+      },
+      {
+        getType: () => 'm.room.redaction',
+        getRedacts: () => 'reaction-redacted'
+      }
+    ]
+    const summary = buildReactionSummaryByEventId(
+      timelineEvents as any,
+      '@alice:example.org'
+    )
+    const messageReactions = summary.get('evt-message') ?? []
+    messageReactions.length.should.equal(0)
+  })
+
+  it('maps message reactions into message payload', () => {
+    const mockRoom = {
+      getLiveTimeline: () => ({
+        getEvents: () => [
+          {
+            getType: () => 'm.room.message',
+            getSender: () => '@alice:example.org',
+            getId: () => 'evt-message',
+            getContent: () => ({
+              body: 'Hello',
+              msgtype: 'm.text'
+            }),
+            isDecryptionFailure: () => false
+          },
+          {
+            getType: () => 'm.reaction',
+            getId: () => 'reaction-1',
+            getSender: () => '@me:example.org',
+            getContent: () => ({
+              'm.relates_to': {
+                rel_type: 'm.annotation',
+                event_id: 'evt-message',
+                key: '🔥'
+              }
+            })
+          }
+        ]
+      }),
+      getMembers: () => [],
+      getMember: () => ({ name: 'Alice' }),
+      hasUserReadEvent: () => false
+    }
+    const messages = mapTimelineEventsToMessages({
+      room: mockRoom as any,
+      ownUserId: '@me:example.org',
+      getMemberAvatarUrl: () => undefined,
+      getMediaUrl: () => undefined,
+      buildNoticeText: () => ''
+    })
+    messages.length.should.equal(1)
+    messages[0]!.reactions.length.should.equal(1)
+    messages[0]!.reactions[0]!.emoji.should.equal('🔥')
+    messages[0]!.reactions[0]!.hasOwnReaction.should.equal(true)
   })
 })


### PR DESCRIPTION
## Summary
- Implement message reactions end-to-end (send, toggle/remove, aggregate by emoji, and mark own reactions) with incremental timeline updates.
- Replace the simple reaction input with a richer emoji picker (categories, search, shortcode conversion like `:wave:` -> `👋`, support for `:people_hugging:` -> `🫂`, and user-scoped frequent emoji tracking in `localStorage`).
- Refactor chat UI structure by extracting media helper logic into `useChatMedia`, and update the message action bar to icon-only controls with native tooltips.
- Add/extend unit and E2E coverage for reaction behavior, picker behavior, and timeline aggregation.

## Scope
### UI / Components
- `ChatMessageActionBar`, `ChatMessageItem`, `ChatMessageList`
- New/extended `ChatReactionEmojiPicker`

### Composables / Utils
- `useMatrixClient`: reaction send/toggle/redaction helpers
- `useEmojiPickerData`: emoji catalog, shortcode normalization, frequent-usage persistence
- `useChatMedia`: extracted media-related helpers
- `chatTimeline` reaction summary mapping

### Tests
- Unit tests for `useMatrixClient`, `chatTimeline`, `MessageItem`, `ReactionEmojiPicker`
- E2E scenario for add/remove reaction flow

## Test Plan
- [x] Unit tests updated for reaction toggle and aggregation mapping
- [x] Unit tests updated for picker shortcode conversion and frequent usage persistence
- [x] E2E scenario verifies add/remove reaction and count updates
- [ ] Full CI run on PR

## Notes
- Frequent emoji data is persisted with a user-scoped storage key.
- Reaction updates are applied incrementally to reduce full timeline remapping.
- Changelog was updated under `Unreleased` for this branch scope.