### PR TITLE
Add dedicated bug issue template and refine feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,54 @@
+---
+name: Bug
+about: Plan and track a bug fix slice
+title: "Bug: "
+labels: ["type:bug"]
+assignees: []
+---
+
+## Goal
+<!-- One short statement of the user-visible bug impact -->
+
+## Scope
+<!-- In scope:
+- Bug source analysis
+- Code fix
+- Required test updates
+-->
+
+## Branch
+`bug/<bugfix>`
+
+## Bug Details
+### Current Behavior
+<!-- What happens today? -->
+
+### Expected Behavior
+<!-- What should happen instead? -->
+
+### Steps to Reproduce
+1. ...
+2. ...
+3. ...
+
+## Acceptance Criteria
+- [ ] Root cause is identified and fixed.
+- [ ] Behavior matches expected result in affected flow.
+- [ ] No regression is introduced in related flow.
+
+## Test Checklist
+### Unit
+- [ ] Add or update unit tests for the bug scenario.
+
+### Integration
+- [ ] Add or update integration tests if cross-component behavior changed.
+
+### E2E
+- [ ] Add or update E2E coverage when user flow is affected.
+
+### Manual
+- [ ] Reproduce bug on current main/develop baseline.
+- [ ] Verify fix with same repro steps after patch.
+
+## Notes
+<!-- Optional context, links, decisions -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -16,7 +16,6 @@ assignees: []
 
 ## Branch
 `feature/<feature>` (Feature)
-`bug/<bugfix>` (Bugfix)
 
 ## Acceptance Criteria
 - [ ] ...

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -15,7 +15,8 @@ assignees: []
 -->
 
 ## Branch
-`feature/<feature>`
+`feature/<feature>` (Feature)
+`bug/<bugfix>` (Bugfix)
 
 ## Acceptance Criteria
 - [ ] ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Dedicated GitHub Bug issue template at `.github/ISSUE_TEMPLATE/bug.md`
+  with `bug/<bugfix>` branch guidance and bug-focused planning/test sections
 - Chat image messages with inline preview and lightbox support
 - E2EE image sending support from chat input
 - Media utilities for encrypted media fetch, decrypt, cache, and revoke flows


### PR DESCRIPTION
## Summary
- add a dedicated bug issue template at `.github/ISSUE_TEMPLATE/bug.md`
- include bug-specific structure (current/expected behavior, repro steps,
  acceptance criteria, and test checklist)
- remove `bug/<bugfix>` guidance from the feature template so
  `.github/ISSUE_TEMPLATE/feature.md` only references `feature/<feature>`
- update `CHANGELOG.md` (`Unreleased`) to reflect these workflow changes

## Why
This separates feature planning from bug-fix planning and keeps branch naming,
labels, and checklists consistent for solo workflow execution.

## Test Plan
- verify both templates exist under `.github/ISSUE_TEMPLATE/`
- verify `feature.md` contains only `feature/<feature>` in branch guidance
- verify `bug.md` contains `bug/<bugfix>` and bug-specific sections
- verify `CHANGELOG.md` includes the new Unreleased entries