### PR TITLE
Implement reCAPTCHA support in signup process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- reCAPTCHA UIA stage (`m.login.recaptcha`) in signup with consent-gated
+  script load and optional iubenda hooks (#57)
+- Optional Synapse-backed E2E for registration captcha (`@recaptcha_signup`);
+  see `tests/e2e/RECAPTCHA-SIGNUP.md`
 - Dedicated GitHub Bug issue template at `.github/ISSUE_TEMPLATE/bug.md`
   with `bug/<bugfix>` branch guidance and bug-focused planning/test sections
 - MVP signup page with Matrix registration and user-facing error feedback (#52)

--- a/app/components/auth/SignupRecaptchaStep.vue
+++ b/app/components/auth/SignupRecaptchaStep.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { RecaptchaV2 } from 'vue3-recaptcha-v2'
+import { executeGoogleRecaptchaV3 } from '~/composables/recaptchaGoogle'
+import { useSignupRecaptchaConsent } from '~/composables/useSignupRecaptchaConsent'
+import { useAppI18n } from '~/composables/useAppI18n'
+
+const props = defineProps<{
+  siteKey: string
+  version: 'v2' | 'v3'
+}>()
+
+const emit = defineEmits<{
+  verified: [token: string]
+}>()
+
+const { translateText } = useAppI18n()
+const {
+  iubendaConfigured,
+  privacyPolicyUrl,
+  canLoadGoogleRecaptcha,
+  grantLocalRecaptchaConsent,
+  openCookiePreferences
+} = useSignupRecaptchaConsent()
+
+const v3Running = ref(false)
+const v3Error = ref('')
+
+const widgetAllowed = computed(() => canLoadGoogleRecaptcha())
+
+const policyHref = computed(() => privacyPolicyUrl())
+
+function onConsentContinue(): void {
+  grantLocalRecaptchaConsent()
+}
+
+function openPrivacy(): void {
+  const url = policyHref.value
+  if (!url) {
+    return
+  }
+  window.open(url, '_blank', 'noopener,noreferrer')
+}
+
+async function runRecaptchaV3(): Promise<void> {
+  v3Error.value = ''
+  v3Running.value = true
+  try {
+    const token = await executeGoogleRecaptchaV3(props.siteKey, 'signup')
+    emit('verified', token)
+  } catch {
+    v3Error.value = translateText('auth.signUpRecaptchaFailed')
+  } finally {
+    v3Running.value = false
+  }
+}
+
+function onRecaptchaV2Verified(response: unknown): void {
+  if (typeof response !== 'string' || !response.trim()) {
+    return
+  }
+  emit('verified', response.trim())
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <p class="text-sm text-gray-400">
+      {{ translateText('auth.signUpCaptchaConsentLead') }}
+    </p>
+    <p class="text-sm text-gray-400">
+      {{ translateText('auth.signUpHomeserverPrivacyNotice') }}
+    </p>
+
+    <div class="flex flex-wrap gap-2">
+      <UButton
+        v-if="policyHref"
+        type="button"
+        color="neutral"
+        variant="outline"
+        size="sm"
+        @click="openPrivacy"
+      >
+        {{ translateText('auth.signUpPrivacyPolicyLink') }}
+      </UButton>
+      <UButton
+        v-if="iubendaConfigured()"
+        type="button"
+        color="neutral"
+        variant="outline"
+        size="sm"
+        @click="openCookiePreferences"
+      >
+        {{ translateText('auth.signUpCookieSettings') }}
+      </UButton>
+    </div>
+
+    <div v-if="!widgetAllowed">
+      <UButton
+        type="button"
+        class="w-full justify-center"
+        @click="onConsentContinue"
+      >
+        {{ translateText('auth.signUpAgreeLoadRecaptcha') }}
+      </UButton>
+    </div>
+
+    <template v-else>
+      <ClientOnly>
+        <RecaptchaV2
+          v-if="version === 'v2'"
+          :sitekey="siteKey"
+          theme="dark"
+          @load-callback="onRecaptchaV2Verified"
+        />
+        <div
+          v-else
+          class="space-y-2"
+        >
+          <UButton
+            type="button"
+            class="w-full justify-center"
+            :loading="v3Running"
+            @click="runRecaptchaV3"
+          >
+            {{ translateText('auth.signUpRunRecaptchaCheck') }}
+          </UButton>
+          <p
+            v-if="v3Error"
+            class="text-sm text-red-400"
+          >
+            {{ v3Error }}
+          </p>
+        </div>
+      </ClientOnly>
+    </template>
+  </div>
+</template>

--- a/app/composables/matrix/matrixClientShared.ts
+++ b/app/composables/matrix/matrixClientShared.ts
@@ -14,6 +14,7 @@ export interface MatrixApiErrorShape {
     session?: string
     completed?: string[]
     flows?: Array<{ stages?: string[] }>
+    params?: Record<string, unknown>
   }
   httpStatus?: number
   statusCode?: number

--- a/app/composables/matrix/matrixRegistrationUia.ts
+++ b/app/composables/matrix/matrixRegistrationUia.ts
@@ -20,22 +20,31 @@ export const SIGNUP_PENDING_MISSING = 'SIGNUP_PENDING_MISSING'
 export const SIGNUP_SESSION_EXPIRED = 'SIGNUP_SESSION_EXPIRED'
 export const SIGNUP_REGISTRATION_UNSUPPORTED_STAGE =
   'SIGNUP_REGISTRATION_UNSUPPORTED_STAGE'
+export const SIGNUP_RECAPTCHA_TOKEN_REQUIRED =
+  'SIGNUP_RECAPTCHA_TOKEN_REQUIRED'
+export const SIGNUP_RECAPTCHA_FAILED = 'SIGNUP_RECAPTCHA_FAILED'
 
 export const SIGNUP_PENDING_STORAGE_KEY = 'decentra.signup.pending.v1'
 
 const SIGNUP_PENDING_V = 1
 
-type SignupPendingStateV1 = {
+export type SignupPendingStateV1 = {
   v: 1
   baseUrl: string
   username: string
   password: string
   email: string
   clientSecret: string
+  /** Present after Homeserver issued registration email token sid */
   sid: string
   session: string
   initialSession: string
   flowStages: string[]
+  paramsSnapshot?: Record<string, unknown>
+  recaptchaSiteKey?: string
+  recaptchaVersion?: 'v2' | 'v3'
+  /** True while user must solve captcha before email token request */
+  needsRecaptchaBeforeEmail?: boolean
 }
 
 function createRegisterEmailClientSecret(): string {
@@ -51,11 +60,13 @@ function createRegisterEmailClientSecret(): string {
 
 const EMAIL_IDENTITY_STAGE = 'm.login.email.identity'
 const DUMMY_STAGE = 'm.login.dummy'
+export const RECAPTCHA_STAGE = 'm.login.recaptcha'
 
 interface MatrixUiaData {
   session?: string
   completed?: string[]
   flows?: Array<{ stages?: string[] }>
+  params?: Record<string, unknown>
 }
 
 function readMatrixUiaData(error: unknown): MatrixUiaData | null {
@@ -73,8 +84,44 @@ function readMatrixUiaData(error: unknown): MatrixUiaData | null {
   return {
     session: data.session,
     flows: data.flows,
-    completed: data.completed
+    completed: data.completed,
+    params: data.params
   }
+}
+
+/**
+ * Parses Synapse/Matrix UIA params for {@link RECAPTCHA_STAGE}.
+ */
+export function extractRecaptchaFromParams(
+  params: Record<string, unknown> | undefined
+): { siteKey: string; version: 'v2' | 'v3' } | null {
+  if (!params || typeof params !== 'object') {
+    return null
+  }
+  const blockUnknown = params[RECAPTCHA_STAGE]
+  if (!blockUnknown || typeof blockUnknown !== 'object') {
+    return null
+  }
+  const block = blockUnknown as Record<string, unknown>
+  const publicKey = block.public_key
+  if (typeof publicKey !== 'string' || !publicKey.trim()) {
+    return null
+  }
+  let version: 'v2' | 'v3' = 'v2'
+  const rawVersion = block.version
+  if (rawVersion === 'v3' || rawVersion === 3) {
+    version = 'v3'
+  }
+  return { siteKey: publicKey.trim(), version }
+}
+
+export function signupPendingNeedsRecaptchaBeforeEmail(): boolean {
+  const pending = readSignupPending()
+  return pending?.needsRecaptchaBeforeEmail === true
+}
+
+export function readSignupPendingPublic(): SignupPendingStateV1 | null {
+  return readSignupPending()
 }
 
 function pickFlowWithEmail(
@@ -181,6 +228,29 @@ function buildDummyAuthPayload(
     type: DUMMY_STAGE,
     session: sessionId
   }
+}
+
+export function buildRecaptchaAuthPayload(
+  sessionId: string,
+  responseToken: string
+): Record<string, unknown> {
+  return {
+    type: RECAPTCHA_STAGE,
+    session: sessionId,
+    response: responseToken
+  }
+}
+
+function isLikelyRecaptchaRejected(error: unknown): boolean {
+  const code = readMatrixErrorCode(error).toUpperCase()
+  if (code.includes('CAPTCHA')) {
+    return true
+  }
+  const message = readMatrixErrorMessage(error).toLowerCase()
+  return (
+    message.includes('recaptcha') ||
+    message.includes('captcha')
+  )
 }
 
 function readSignupPending(): SignupPendingStateV1 | null {
@@ -299,6 +369,38 @@ export async function startEmailRegistration(
       }
       throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
     }
+    const paramsRaw = uia.params
+    const params: Record<string, unknown> =
+      paramsRaw &&
+      typeof paramsRaw === 'object' &&
+      !Array.isArray(paramsRaw)
+        ? (paramsRaw as Record<string, unknown>)
+        : {}
+    const completedInitial = uia.completed || []
+    const firstStage = getNextAuthStage(flowStages, completedInitial)
+    const recMeta = extractRecaptchaFromParams(params)
+
+    if (firstStage === RECAPTCHA_STAGE) {
+      const pendingCaptchaFirst: SignupPendingStateV1 = {
+        v: SIGNUP_PENDING_V,
+        baseUrl: resolved,
+        username: normUser,
+        password,
+        email: trimmed,
+        clientSecret,
+        sid: '',
+        session: uia.session,
+        initialSession: uia.session,
+        flowStages,
+        paramsSnapshot: params,
+        recaptchaSiteKey: recMeta?.siteKey,
+        recaptchaVersion: recMeta?.version ?? 'v2',
+        needsRecaptchaBeforeEmail: true
+      }
+      writeSignupPending(pendingCaptchaFirst)
+      return
+    }
+
     if (typeof authClient.requestRegisterEmailToken !== 'function') {
       throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
     }
@@ -322,28 +424,36 @@ export async function startEmailRegistration(
       sid,
       session: uia.session,
       initialSession: uia.session,
-      flowStages
+      flowStages,
+      paramsSnapshot: Object.keys(params).length > 0 ? params : undefined,
+      recaptchaSiteKey: recMeta?.siteKey,
+      recaptchaVersion: recMeta?.version,
+      needsRecaptchaBeforeEmail: false
     }
     writeSignupPending(pending)
   }
 }
 
-export async function finalizeEmailRegistration(): Promise<void> {
-  if (typeof window === 'undefined') {
-    throw new Error(SIGNUP_PENDING_MISSING)
-  }
-  const pending = readSignupPending()
-  if (!pending) {
-    throw new Error(SIGNUP_PENDING_MISSING)
-  }
-  const authClient = sdk.createClient({
-    baseUrl: resolveHomeserverBaseUrlForClient(pending.baseUrl)
-  }) as RegisterAuthClient
-  if (typeof authClient.registerRequest !== 'function') {
-    throw new Error(SIGNUP_UNAVAILABLE_ERROR)
-  }
-  let session = pending.session
-  let completedList: string[] = []
+type FinalizeLoopOptions = {
+  recaptchaResponse?: string | null
+  initialCompleted?: string[]
+  initialSession?: string | null
+}
+
+async function runSignupFinalizeLoop(
+  pending: SignupPendingStateV1,
+  authClient: RegisterAuthClient,
+  loopOptions?: FinalizeLoopOptions
+): Promise<void> {
+  let session =
+    loopOptions?.initialSession != null &&
+      loopOptions.initialSession !== ''
+      ? loopOptions.initialSession
+      : pending.session
+  let completedList = [...(loopOptions?.initialCompleted ?? [])]
+  let pendingRecaptchaToken =
+    loopOptions?.recaptchaResponse?.trim() ?? ''
+
   for (let round = 0; round < 12; round++) {
     const nextStage = getNextAuthStage(
       pending.flowStages,
@@ -361,6 +471,13 @@ export async function finalizeEmailRegistration(): Promise<void> {
       )
     } else if (nextStage === DUMMY_STAGE) {
       authPayload = buildDummyAuthPayload(session)
+    } else if (nextStage === RECAPTCHA_STAGE) {
+      const tokenToSend = pendingRecaptchaToken
+      if (!tokenToSend) {
+        throw new Error(SIGNUP_RECAPTCHA_TOKEN_REQUIRED)
+      }
+      pendingRecaptchaToken = ''
+      authPayload = buildRecaptchaAuthPayload(session, tokenToSend)
     } else {
       throw new Error(SIGNUP_REGISTRATION_UNSUPPORTED_STAGE)
     }
@@ -386,6 +503,12 @@ export async function finalizeEmailRegistration(): Promise<void> {
       ) {
         throw new Error(SIGNUP_EMAIL_NOT_CONFIRMED_YET)
       }
+      if (
+        nextStage === RECAPTCHA_STAGE &&
+        isLikelyRecaptchaRejected(error)
+      ) {
+        throw new Error(SIGNUP_RECAPTCHA_FAILED)
+      }
       const uia = readMatrixUiaData(error)
       if (uia) {
         if (
@@ -398,12 +521,42 @@ export async function finalizeEmailRegistration(): Promise<void> {
         ) {
           throw new Error(SIGNUP_SESSION_EXPIRED)
         }
+        if (
+          round === 0 &&
+          nextStage === RECAPTCHA_STAGE &&
+          uia.session &&
+          uia.session !== pending.session &&
+          !(uia.completed || []).includes(RECAPTCHA_STAGE)
+        ) {
+          throw new Error(SIGNUP_SESSION_EXPIRED)
+        }
         if (uia.session) {
           session = uia.session
         }
         if (Array.isArray(uia.completed)) {
           completedList = [...(uia.completed as string[])]
         }
+        const mergedParams =
+          uia.params &&
+          typeof uia.params === 'object' &&
+          !Array.isArray(uia.params)
+            ? (uia.params as Record<string, unknown>)
+            : undefined
+        if (mergedParams) {
+          pending.paramsSnapshot = {
+            ...(pending.paramsSnapshot ?? {}),
+            ...mergedParams
+          }
+          const recMeta = extractRecaptchaFromParams(
+            pending.paramsSnapshot
+          )
+          if (recMeta) {
+            pending.recaptchaSiteKey = recMeta.siteKey
+            pending.recaptchaVersion = recMeta.version
+          }
+        }
+        pending.session = session
+        writeSignupPending(pending)
         continue
       }
       if (
@@ -423,6 +576,135 @@ export async function finalizeEmailRegistration(): Promise<void> {
     }
   }
   throw new Error('Sign up failed')
+}
+
+export async function submitSignupRecaptcha(
+  response: string
+): Promise<void> {
+  if (typeof window === 'undefined') {
+    throw new Error(SIGNUP_PENDING_MISSING)
+  }
+  const trimmedResponse = response.trim()
+  if (!trimmedResponse) {
+    throw new Error(SIGNUP_RECAPTCHA_FAILED)
+  }
+  const pending = readSignupPending()
+  if (!pending) {
+    throw new Error(SIGNUP_PENDING_MISSING)
+  }
+  if (!pending.needsRecaptchaBeforeEmail) {
+    throw new Error(SIGNUP_RECAPTCHA_FAILED)
+  }
+  const authClient = sdk.createClient({
+    baseUrl: resolveHomeserverBaseUrlForClient(pending.baseUrl)
+  }) as RegisterAuthClient
+  if (typeof authClient.registerRequest !== 'function') {
+    throw new Error(SIGNUP_UNAVAILABLE_ERROR)
+  }
+  try {
+    await authClient.registerRequest({
+      username: pending.username,
+      password: pending.password,
+      inhibit_login: true,
+      auth: buildRecaptchaAuthPayload(pending.session, trimmedResponse)
+    })
+    clearSignupPending()
+    return
+  } catch (error) {
+    if (isLikelyBrowserNetworkOrCorsError(error)) {
+      throw new Error(HOMESERVER_CONNECTION_HINT_ERROR)
+    }
+    if (isLikelyRecaptchaRejected(error)) {
+      throw new Error(SIGNUP_RECAPTCHA_FAILED)
+    }
+    const uia = readMatrixUiaData(error)
+    if (!uia) {
+      if (isSignupUnsupported(error)) {
+        throw new Error(SIGNUP_UNAVAILABLE_ERROR)
+      }
+      const matrixMessage = readMatrixErrorMessage(error)
+      if (matrixMessage) {
+        throw new Error(matrixMessage)
+      }
+      throw error
+    }
+    if (uia.session) {
+      pending.session = uia.session
+    }
+    const mergedParamsSubmit =
+      uia.params &&
+      typeof uia.params === 'object' &&
+      !Array.isArray(uia.params)
+        ? (uia.params as Record<string, unknown>)
+        : undefined
+    if (mergedParamsSubmit) {
+      pending.paramsSnapshot = {
+        ...(pending.paramsSnapshot ?? {}),
+        ...mergedParamsSubmit
+      }
+      const recMetaSubmit = extractRecaptchaFromParams(
+        pending.paramsSnapshot
+      )
+      if (recMetaSubmit) {
+        pending.recaptchaSiteKey = recMetaSubmit.siteKey
+        pending.recaptchaVersion = recMetaSubmit.version
+      }
+    }
+    pending.needsRecaptchaBeforeEmail = false
+    writeSignupPending(pending)
+
+    const completedList = uia.completed || []
+    const nextStage = getNextAuthStage(
+      pending.flowStages,
+      completedList
+    )
+    const nextLink = `${window.location.origin}/signup/verify-email`
+
+    if (nextStage === EMAIL_IDENTITY_STAGE && !pending.sid) {
+      if (typeof authClient.requestRegisterEmailToken !== 'function') {
+        throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
+      }
+      const token = await authClient.requestRegisterEmailToken(
+        pending.email,
+        pending.clientSecret,
+        1,
+        nextLink
+      ) as { sid?: string }
+      const sid = token.sid
+      if (!sid) {
+        throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
+      }
+      pending.sid = sid
+      writeSignupPending(pending)
+      return
+    }
+
+    await runSignupFinalizeLoop(pending, authClient, {
+      initialCompleted: completedList,
+      initialSession: pending.session
+    })
+  }
+}
+
+export async function finalizeEmailRegistration(
+  options?: { recaptchaResponse?: string | null }
+): Promise<void> {
+  if (typeof window === 'undefined') {
+    throw new Error(SIGNUP_PENDING_MISSING)
+  }
+  const pending = readSignupPending()
+  if (!pending) {
+    throw new Error(SIGNUP_PENDING_MISSING)
+  }
+  const authClient = sdk.createClient({
+    baseUrl: resolveHomeserverBaseUrlForClient(pending.baseUrl)
+  }) as RegisterAuthClient
+  if (typeof authClient.registerRequest !== 'function') {
+    throw new Error(SIGNUP_UNAVAILABLE_ERROR)
+  }
+  await runSignupFinalizeLoop(pending, authClient, {
+    recaptchaResponse: options?.recaptchaResponse
+  })
 }
 
 /**

--- a/app/composables/recaptchaGoogle.ts
+++ b/app/composables/recaptchaGoogle.ts
@@ -1,0 +1,55 @@
+/**
+ * Loads Google reCAPTCHA v3 client script and executes once for a site key.
+ */
+
+declare global {
+  interface Window {
+    grecaptcha?: {
+      ready: (callback: () => void) => void
+      execute: (
+        siteKey: string,
+        options: { action: string }
+      ) => Promise<string>
+    }
+  }
+}
+
+function scriptSelector(siteKey: string): string {
+  return `script[data-decentra-recaptcha-v3="${siteKey}"]`
+}
+
+async function ensureRecaptchaV3Script(siteKey: string): Promise<void> {
+  if (typeof document === 'undefined') {
+    throw new Error('recaptcha-v3-no-document')
+  }
+  const existing = document.querySelector(scriptSelector(siteKey))
+  if (existing && window.grecaptcha?.execute) {
+    return
+  }
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const scriptElement = document.createElement('script')
+    scriptElement.src =
+      `https://www.google.com/recaptcha/api.js?render=` +
+      `${encodeURIComponent(siteKey)}`
+    scriptElement.async = true
+    scriptElement.dataset.decentraRecaptchaV3 = siteKey
+    scriptElement.onload = () => resolvePromise()
+    scriptElement.onerror = () => rejectPromise(new Error('recaptcha-v3-load'))
+    document.head.appendChild(scriptElement)
+  })
+}
+
+export async function executeGoogleRecaptchaV3(
+  siteKey: string,
+  action: string
+): Promise<string> {
+  await ensureRecaptchaV3Script(siteKey)
+  const client = window.grecaptcha
+  if (!client?.execute || !client.ready) {
+    throw new Error('recaptcha-v3-unavailable')
+  }
+  await new Promise<void>((resolveReady) => {
+    client.ready(() => resolveReady())
+  })
+  return client.execute(siteKey, { action })
+}

--- a/app/composables/useAppI18n.ts
+++ b/app/composables/useAppI18n.ts
@@ -37,6 +37,23 @@ const messages: Record<AppLocale, Record<string, string>> = {
       'does not support yet.',
     'auth.signUpRetry': 'Try again',
     'auth.signUpBackToForm': 'Back to sign-up',
+    'auth.signUpCaptchaTitle': 'Verify you are human',
+    'auth.signUpCaptchaConsentLead':
+      'Google reCAPTCHA loads only after you agree. Google may process ' +
+      'technical data (also outside the EU).',
+    'auth.signUpHomeserverPrivacyNotice':
+      'Your chosen Matrix homeserver operator processes signup data under ' +
+      'their own rules; Decentra cannot describe every homeserver.',
+    'auth.signUpPrivacyPolicyLink': 'Privacy policy',
+    'auth.signUpCookieSettings': 'Cookie settings',
+    'auth.signUpAgreeLoadRecaptcha': 'Agree and load reCAPTCHA',
+    'auth.signUpRunRecaptchaCheck': 'Run automatic check',
+    'auth.signUpRecaptchaMissingSiteKey':
+      'The homeserver did not send a reCAPTCHA site key.',
+    'auth.signUpRecaptchaFailed':
+      'reCAPTCHA verification failed. Please try again.',
+    'auth.signUpRecaptchaRequired':
+      'Complete reCAPTCHA to continue.',
     'auth.homeserverConnectionHint':
       'Cannot reach the homeserver from the browser. For public ' +
       'servers use https:// (not http://) so a redirect does not break ' +
@@ -215,6 +232,24 @@ const messages: Record<AppLocale, Record<string, string>> = {
       'den Decentra noch nicht unterstuetzt.',
     'auth.signUpRetry': 'Erneut versuchen',
     'auth.signUpBackToForm': 'Zurueck zur Registrierung',
+    'auth.signUpCaptchaTitle': 'Bestaetigung gegen Bots',
+    'auth.signUpCaptchaConsentLead':
+      'Google reCAPTCHA wird erst nach Zustimmung geladen. Google kann ' +
+      'technische Daten verarbeiten (auch ausserhalb der EU).',
+    'auth.signUpHomeserverPrivacyNotice':
+      'Der Betreiber deines gewaehlten Matrix-Homeservers verarbeitet ' +
+      'Registrierungsdaten nach eigener Datenschutzerklaerung; Decentra ' +
+      'kann nicht jeden Homeserver beschreiben.',
+    'auth.signUpPrivacyPolicyLink': 'Datenschutzerklaerung',
+    'auth.signUpCookieSettings': 'Cookie-Einstellungen',
+    'auth.signUpAgreeLoadRecaptcha': 'Zustimmen und reCAPTCHA laden',
+    'auth.signUpRunRecaptchaCheck': 'Automatische Pruefung starten',
+    'auth.signUpRecaptchaMissingSiteKey':
+      'Der Homeserver hat keinen reCAPTCHA-Site-Key gesendet.',
+    'auth.signUpRecaptchaFailed':
+      'reCAPTCHA-Verifikation fehlgeschlagen. Bitte erneut versuchen.',
+    'auth.signUpRecaptchaRequired':
+      'Bitte reCAPTCHA abschliessen, um fortzufahren.',
     'auth.homeserverConnectionHint':
       'Homeserver aus dem Browser nicht erreichbar. Oeffentliche ' +
       'Server: https:// statt http:// (sonst bricht CORS-Preflight). Synapse ' +

--- a/app/composables/useMatrixClient.ts
+++ b/app/composables/useMatrixClient.ts
@@ -23,12 +23,17 @@ export { HOMESERVER_CONNECTION_HINT_ERROR, isSameHomeserver, resolveHomeserverBa
 import {
   clearSignupPending,
   finalizeEmailRegistration,
+  readSignupPendingPublic,
   registerWithDummy,
+  signupPendingNeedsRecaptchaBeforeEmail,
   startEmailRegistration,
+  submitSignupRecaptcha,
   SIGNUP_EMAIL_NOT_CONFIRMED_YET,
   SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR,
   SIGNUP_PENDING_MISSING,
   SIGNUP_PENDING_STORAGE_KEY,
+  SIGNUP_RECAPTCHA_FAILED,
+  SIGNUP_RECAPTCHA_TOKEN_REQUIRED,
   SIGNUP_REGISTRATION_UNSUPPORTED_STAGE,
   SIGNUP_SESSION_EXPIRED,
   SIGNUP_UNAVAILABLE_ERROR
@@ -36,16 +41,27 @@ import {
 export {
   clearSignupPending,
   finalizeEmailRegistration,
+  readSignupPendingPublic,
   registerWithDummy,
+  signupPendingNeedsRecaptchaBeforeEmail,
   startEmailRegistration,
+  submitSignupRecaptcha,
   SIGNUP_EMAIL_NOT_CONFIRMED_YET,
   SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR,
   SIGNUP_PENDING_MISSING,
   SIGNUP_PENDING_STORAGE_KEY,
+  SIGNUP_RECAPTCHA_FAILED,
+  SIGNUP_RECAPTCHA_TOKEN_REQUIRED,
   SIGNUP_REGISTRATION_UNSUPPORTED_STAGE,
   SIGNUP_SESSION_EXPIRED,
   SIGNUP_UNAVAILABLE_ERROR
 }
+export type { SignupPendingStateV1 } from './matrix/matrixRegistrationUia'
+export {
+  buildRecaptchaAuthPayload,
+  extractRecaptchaFromParams,
+  RECAPTCHA_STAGE
+} from './matrix/matrixRegistrationUia'
 
 interface StoredMatrixSession {
   baseUrl: string
@@ -1154,6 +1170,9 @@ export function useMatrixClient() {
     startEmailRegistration,
     finalizeEmailRegistration,
     clearSignupPending,
+    submitSignupRecaptcha,
+    signupPendingNeedsRecaptchaBeforeEmail,
+    readSignupPendingPublic,
     logout,
     getRooms,
     getRoom,

--- a/app/composables/useSignupRecaptchaConsent.ts
+++ b/app/composables/useSignupRecaptchaConsent.ts
@@ -1,0 +1,128 @@
+/**
+ * Consent helpers for loading Google reCAPTCHA during signup (GDPR-oriented).
+ *
+ * Optional iubenda Cookie Solution is injected via `plugins/iubenda.client.ts`.
+ * If iubenda IDs are missing, only explicit local consent applies.
+ */
+
+import { ref } from 'vue'
+
+export function useSignupRecaptchaConsent() {
+  const runtimeConfig = useRuntimeConfig()
+
+  const localConsentGranted = ref(false)
+
+  function iubendaConfigured(): boolean {
+    const siteId = String(runtimeConfig.public.iubendaSiteId ?? '').trim()
+    const policyId = String(
+      runtimeConfig.public.iubendaCookiePolicyId ?? ''
+    ).trim()
+    return !!(siteId && policyId)
+  }
+
+  function privacyPolicyUrl(): string {
+    return String(runtimeConfig.public.iubendaPrivacyPolicyUrl ?? '').trim()
+  }
+
+  function parsePurposeIds(): number[] {
+    const raw = String(
+      runtimeConfig.public.iubendaRecaptchaPurposeIds ?? ''
+    ).trim()
+    if (!raw) {
+      return []
+    }
+    return raw
+      .split(',')
+      .map((part) => Number(part.trim()))
+      .filter((value) => Number.isFinite(value))
+  }
+
+  function readIubendaApi(): Record<string, unknown> | null {
+    if (typeof window === 'undefined') {
+      return null
+    }
+    const bridge = window as unknown as {
+      _iub?: { cs?: { api?: Record<string, unknown> } }
+    }
+    const api = bridge._iub?.cs?.api
+    return api && typeof api === 'object' ? api : null
+  }
+
+  /**
+   * Best-effort check when purpose IDs are configured in runtime config.
+   */
+  function hasConfiguredPurposeConsent(): boolean {
+    const purposeIds = parsePurposeIds()
+    if (purposeIds.length === 0) {
+      return false
+    }
+    const api = readIubendaApi()
+    if (!api) {
+      return false
+    }
+    const candidates = [
+      api.hasConsentedPurpose,
+      api.isPurposeAccepted,
+      api.hasConsentForPurpose
+    ]
+    for (const candidate of candidates) {
+      if (typeof candidate !== 'function') {
+        continue
+      }
+      const checker = candidate as (purposeId: number) => boolean
+      try {
+        if (purposeIds.some((purposeId) => checker.call(api, purposeId))) {
+          return true
+        }
+      } catch {
+        continue
+      }
+    }
+    return false
+  }
+
+  function canLoadGoogleRecaptcha(): boolean {
+    if (localConsentGranted.value) {
+      return true
+    }
+    if (iubendaConfigured() && hasConfiguredPurposeConsent()) {
+      return true
+    }
+    return false
+  }
+
+  function grantLocalRecaptchaConsent(): void {
+    localConsentGranted.value = true
+  }
+
+  function openCookiePreferences(): void {
+    const api = readIubendaApi()
+    if (!api) {
+      return
+    }
+    const openerCandidates = [
+      api.openPreferenceCenter,
+      api.openPreferences,
+      api.openCmp
+    ]
+    for (const candidate of openerCandidates) {
+      if (typeof candidate === 'function') {
+        try {
+          ;(candidate as () => void).call(api)
+          return
+        } catch {
+          continue
+        }
+      }
+    }
+  }
+
+  return {
+    localConsentGranted,
+    iubendaConfigured,
+    privacyPolicyUrl,
+    canLoadGoogleRecaptcha,
+    grantLocalRecaptchaConsent,
+    openCookiePreferences
+  }
+}

--- a/app/pages/signup.vue
+++ b/app/pages/signup.vue
@@ -2,15 +2,19 @@
 import { ref } from 'vue'
 import {
   clearSignupPending,
+  extractRecaptchaFromParams,
   HOMESERVER_CONNECTION_HINT_ERROR,
+  readSignupPendingPublic,
   SIGNUP_EMAIL_NOT_CONFIRMED_YET,
   SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR,
   SIGNUP_PENDING_MISSING,
   SIGNUP_PENDING_STORAGE_KEY,
+  SIGNUP_RECAPTCHA_FAILED,
   SIGNUP_REGISTRATION_UNSUPPORTED_STAGE,
   SIGNUP_SESSION_EXPIRED,
   SIGNUP_UNAVAILABLE_ERROR,
   startEmailRegistration,
+  submitSignupRecaptcha,
   useMatrixClient
 } from '~/composables/useMatrixClient'
 import { useAppI18n } from '~/composables/useAppI18n'
@@ -21,7 +25,10 @@ const username = ref('')
 const password = ref('')
 const error = ref('')
 const loading = ref(false)
-const step = ref<'form' | 'emailSent'>('form')
+const step = ref<'form' | 'emailSent' | 'captcha'>('form')
+
+const captchaSiteKey = ref('')
+const captchaVersion = ref<'v2' | 'v3'>('v2')
 
 const { isLoggedIn } = useMatrixClient()
 const { translateText } = useAppI18n()
@@ -56,6 +63,9 @@ function mapSignupError(thrown: unknown): string {
   if (m === SIGNUP_REGISTRATION_UNSUPPORTED_STAGE) {
     return translateText('auth.signUpUnsupportedAuthStage')
   }
+  if (m === SIGNUP_RECAPTCHA_FAILED) {
+    return translateText('auth.signUpRecaptchaFailed')
+  }
   return translateText('auth.signUpFailed')
 }
 
@@ -65,6 +75,23 @@ function emailSentBodyText(): string {
     '{email}',
     email.value.trim() || '—'
   )
+}
+
+function hydrateCaptchaFromPending(): void {
+  const pending = readSignupPendingPublic()
+  if (!pending) {
+    captchaSiteKey.value = ''
+    return
+  }
+  const fromParams = extractRecaptchaFromParams(pending.paramsSnapshot)
+  captchaSiteKey.value =
+    pending.recaptchaSiteKey?.trim() ||
+    fromParams?.siteKey ||
+    ''
+  captchaVersion.value =
+    pending.recaptchaVersion ||
+    fromParams?.version ||
+    'v2'
 }
 
 async function handleSignup() {
@@ -81,7 +108,28 @@ async function handleSignup() {
     const isBrowserClient = typeof window !== 'undefined' &&
       (import.meta as { client?: boolean }).client !== false
     if (isBrowserClient) {
-      if (sessionStorage.getItem(SIGNUP_PENDING_STORAGE_KEY)) {
+      const rawPending = sessionStorage.getItem(SIGNUP_PENDING_STORAGE_KEY)
+      if (rawPending) {
+        try {
+          const parsed = JSON.parse(rawPending) as {
+            needsRecaptchaBeforeEmail?: boolean
+          }
+          if (parsed.needsRecaptchaBeforeEmail === true) {
+            hydrateCaptchaFromPending()
+            if (!captchaSiteKey.value.trim()) {
+              error.value = translateText(
+                'auth.signUpRecaptchaMissingSiteKey'
+              )
+              step.value = 'form'
+              return
+            }
+            step.value = 'captcha'
+            return
+          }
+        } catch {
+          step.value = 'emailSent'
+          return
+        }
         step.value = 'emailSent'
         return
       }
@@ -97,10 +145,36 @@ async function handleSignup() {
   }
 }
 
+async function handleCaptchaVerified(token: string) {
+  error.value = ''
+  loading.value = true
+  try {
+    await submitSignupRecaptcha(token)
+    const pendingAfter = readSignupPendingPublic()
+    if (!pendingAfter) {
+      await navigateTo({
+        path: '/login',
+        query: { signup: 'success' }
+      })
+      return
+    }
+    if (pendingAfter.sid) {
+      step.value = 'emailSent'
+      return
+    }
+    error.value = translateText('auth.signUpFailed')
+  } catch (thrownError) {
+    error.value = mapSignupError(thrownError)
+  } finally {
+    loading.value = false
+  }
+}
+
 function resetToForm() {
   clearSignupPending()
   step.value = 'form'
   error.value = ''
+  captchaSiteKey.value = ''
 }
 
 function clearForm() {
@@ -111,6 +185,7 @@ function clearForm() {
   error.value = ''
   clearSignupPending()
   step.value = 'form'
+  captchaSiteKey.value = ''
 }
 </script>
 
@@ -225,6 +300,40 @@ function clearForm() {
             </UButton>
           </div>
         </form>
+      </UCard>
+
+      <UCard
+        v-else-if="step === 'captcha'"
+        class="w-full max-w-md"
+      >
+        <template #header>
+          <h1 class="text-xl font-semibold">
+            {{ translateText('auth.signUpCaptchaTitle') }}
+          </h1>
+        </template>
+        <div class="space-y-4">
+          <UAlert
+            v-if="error"
+            color="error"
+            :title="error"
+            class="mb-2"
+          />
+          <SignupRecaptchaStep
+            :site-key="captchaSiteKey"
+            :version="captchaVersion"
+            @verified="handleCaptchaVerified"
+          />
+          <UButton
+            type="button"
+            color="neutral"
+            variant="outline"
+            class="w-full justify-center"
+            :disabled="loading"
+            @click="resetToForm"
+          >
+            {{ translateText('auth.signUpCancel') }}
+          </UButton>
+        </div>
       </UCard>
 
       <UCard

--- a/app/pages/signup/verify-email.vue
+++ b/app/pages/signup/verify-email.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import {
+  extractRecaptchaFromParams,
   finalizeEmailRegistration,
   HOMESERVER_CONNECTION_HINT_ERROR,
+  readSignupPendingPublic,
   SIGNUP_EMAIL_NOT_CONFIRMED_YET,
   SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR,
   SIGNUP_PENDING_MISSING,
+  SIGNUP_RECAPTCHA_FAILED,
+  SIGNUP_RECAPTCHA_TOKEN_REQUIRED,
   SIGNUP_REGISTRATION_UNSUPPORTED_STAGE,
   SIGNUP_SESSION_EXPIRED,
   SIGNUP_UNAVAILABLE_ERROR,
@@ -15,12 +19,32 @@ import { useAppI18n } from '~/composables/useAppI18n'
 
 const loading = ref(true)
 const error = ref('')
+const needsCaptcha = ref(false)
+const captchaSiteKey = ref('')
+const captchaVersion = ref<'v2' | 'v3'>('v2')
 
 const { isLoggedIn } = useMatrixClient()
 const { translateText } = useAppI18n()
 
 if (isLoggedIn.value) {
   navigateTo('/chat')
+}
+
+function hydrateCaptchaFromPending(): void {
+  const pending = readSignupPendingPublic()
+  if (!pending) {
+    captchaSiteKey.value = ''
+    return
+  }
+  const fromParams = extractRecaptchaFromParams(pending.paramsSnapshot)
+  captchaSiteKey.value =
+    pending.recaptchaSiteKey?.trim() ||
+    fromParams?.siteKey ||
+    ''
+  captchaVersion.value =
+    pending.recaptchaVersion ||
+    fromParams?.version ||
+    'v2'
 }
 
 function mapError(thrown: unknown): string {
@@ -49,23 +73,46 @@ function mapError(thrown: unknown): string {
   if (m === SIGNUP_REGISTRATION_UNSUPPORTED_STAGE) {
     return translateText('auth.signUpUnsupportedAuthStage')
   }
+  if (m === SIGNUP_RECAPTCHA_FAILED) {
+    return translateText('auth.signUpRecaptchaFailed')
+  }
+  if (m === SIGNUP_RECAPTCHA_TOKEN_REQUIRED) {
+    return translateText('auth.signUpRecaptchaRequired')
+  }
   return translateText('auth.signUpFailed')
 }
 
-async function runFinalize() {
+async function runFinalize(recaptchaToken?: string | null) {
   error.value = ''
   loading.value = true
   try {
-    await finalizeEmailRegistration()
+    await finalizeEmailRegistration({
+      recaptchaResponse: recaptchaToken ?? undefined
+    })
     await navigateTo({
       path: '/login',
       query: { signup: 'success' }
     })
   } catch (thrownError) {
+    if (
+      thrownError instanceof Error &&
+      thrownError.message === SIGNUP_RECAPTCHA_TOKEN_REQUIRED
+    ) {
+      needsCaptcha.value = true
+      hydrateCaptchaFromPending()
+      if (!captchaSiteKey.value.trim()) {
+        error.value = translateText('auth.signUpRecaptchaMissingSiteKey')
+      }
+      return
+    }
     error.value = mapError(thrownError)
   } finally {
     loading.value = false
   }
+}
+
+async function handleCaptchaVerified(token: string) {
+  await runFinalize(token)
 }
 
 onMounted(() => {
@@ -101,12 +148,16 @@ onMounted(() => {
       <UCard class="w-full max-w-md">
         <template #header>
           <h1 class="text-xl font-semibold">
-            {{ translateText('auth.signUpEmailVerifyingTitle') }}
+            {{
+              needsCaptcha
+                ? translateText('auth.signUpCaptchaTitle')
+                : translateText('auth.signUpEmailVerifyingTitle')
+            }}
           </h1>
         </template>
         <div class="space-y-4">
           <div
-            v-if="loading"
+            v-if="loading && !needsCaptcha"
             class="text-sm text-gray-500 dark:text-gray-300"
           >
             {{ translateText('auth.signUpEmailVerifyingTitle') }}
@@ -117,18 +168,37 @@ onMounted(() => {
             :title="error"
             class="mb-2"
           />
+          <SignupRecaptchaStep
+            v-if="needsCaptcha && captchaSiteKey.trim()"
+            :site-key="captchaSiteKey"
+            :version="captchaVersion"
+            @verified="handleCaptchaVerified"
+          />
           <div
-            v-if="!loading"
+            v-if="!loading && !needsCaptcha"
             class="flex flex-col gap-2"
           >
             <UButton
               v-if="error"
               class="w-full justify-center"
               :loading="loading"
-              @click="runFinalize"
+              @click="runFinalize()"
             >
               {{ translateText('auth.signUpRetry') }}
             </UButton>
+            <UButton
+              to="/signup"
+              color="neutral"
+              variant="outline"
+              class="w-full justify-center"
+            >
+              {{ translateText('auth.signUpBackToForm') }}
+            </UButton>
+          </div>
+          <div
+            v-if="needsCaptcha && !captchaSiteKey.trim() && !loading"
+            class="flex flex-col gap-2"
+          >
             <UButton
               to="/signup"
               color="neutral"

--- a/app/plugins/iubenda.client.ts
+++ b/app/plugins/iubenda.client.ts
@@ -1,0 +1,56 @@
+export default defineNuxtPlugin(() => {
+  const runtimePublic = useRuntimeConfig().public
+  const siteIdRaw = String(runtimePublic.iubendaSiteId ?? '').trim()
+  const cookiePolicyIdRaw = String(
+    runtimePublic.iubendaCookiePolicyId ?? ''
+  ).trim()
+
+  const siteId = Number(siteIdRaw)
+  const cookiePolicyId = Number(cookiePolicyIdRaw)
+
+  if (
+    !siteIdRaw ||
+    !cookiePolicyIdRaw ||
+    Number.isNaN(siteId) ||
+    Number.isNaN(cookiePolicyId)
+  ) {
+    return
+  }
+
+  const lang = String(runtimePublic.iubendaLang ?? 'de').trim() || 'de'
+
+  const configuration = {
+    siteId,
+    cookiePolicyId,
+    lang,
+    priorConsent: true,
+    perPurposeConsent: true,
+    consentOnContinuedBrowsing: false,
+    gdprAppliesGlobally: false,
+    banner: {
+      acceptButtonDisplay: true,
+      customizeButtonDisplay: true,
+      rejectButtonDisplay: true,
+      position: 'float-bottom-right'
+    }
+  }
+
+  useHead({
+    script: [
+      {
+        key: 'iubenda-cs-configuration',
+        innerHTML:
+          `var _iub=_iub||{};_iub.csConfiguration=` +
+          `${JSON.stringify(configuration)};`,
+        type: 'text/javascript'
+      },
+      {
+        key: 'iubenda-cs-core',
+        src: 'https://cdn.iubenda.com/cs/iubenda_cs.js',
+        type: 'text/javascript',
+        defer: true,
+        async: true
+      }
+    ]
+  })
+})

--- a/app/plugins/recaptcha-v2.client.ts
+++ b/app/plugins/recaptcha-v2.client.ts
@@ -1,0 +1,5 @@
+import { install as installRecaptchaV2 } from 'vue3-recaptcha-v2'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(installRecaptchaV2)
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,15 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   modules: ['@nuxt/ui'],
   css: ['~/assets/css/main.css'],
+  runtimeConfig: {
+    public: {
+      iubendaSiteId: '',
+      iubendaCookiePolicyId: '',
+      iubendaLang: 'de',
+      iubendaRecaptchaPurposeIds: '',
+      iubendaPrivacyPolicyUrl: ''
+    }
+  },
   app: {
     head: {
       title: 'Decentra',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "matrix-js-sdk": "^37.5.0",
         "nuxt": "^4.3.1",
         "vue": "^3.5.28",
-        "vue-router": "^4.6.4"
+        "vue-router": "^4.6.4",
+        "vue3-recaptcha-v2": "^2.1.0"
       },
       "devDependencies": {
         "@cucumber/cucumber": "^11.0.0",
@@ -17444,6 +17445,15 @@
       },
       "peerDependencies": {
         "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue3-recaptcha-v2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vue3-recaptcha-v2/-/vue3-recaptcha-v2-2.1.0.tgz",
+      "integrity": "sha512-dy1qieyWkRHR0yfuHaiI4aPKAsDJ/9Gwl58bl7gU9UtDMOfFAAmimMbyuYTRdxNU90dapJ5LLf2u+2h+gfOiSg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3"
       }
     },
     "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "test:e2e": "node tests/e2e/scripts/run-synapse-e2e.mjs",
     "test:e2e:run": "nuxt build && start-server-and-test preview 3000 node tests/e2e/scripts/run-cucumber-exclude-email.mjs",
     "test:e2e:run:email": "nuxt build && start-server-and-test preview 3000 node tests/e2e/scripts/run-cucumber-email-only.mjs",
+    "test:e2e:run:recaptcha": "nuxt build && start-server-and-test preview 3000 node tests/e2e/scripts/run-cucumber-recaptcha-only.mjs",
     "test:e2e:smoke": "nuxt build && start-server-and-test preview 3000 \"cucumber-js --tags @smoke\"",
     "test:e2e:signup-email": "cross-env DECENTRA_E2E_SIGNUP_EMAIL=1 node tests/e2e/scripts/run-synapse-e2e-signup-email.mjs",
+    "test:e2e:signup-recaptcha": "cross-env DECENTRA_E2E_SIGNUP_RECAPTCHA=1 node tests/e2e/scripts/run-synapse-e2e-signup-recaptcha.mjs",
     "test:coverage": "vitest run --coverage",
     "test:ci:fast": "npm run test:unit && npm run test:integration && npm run test:e2e:smoke",
     "test:ci:full": "npm run test:unit && npm run test:integration && npm run test:coverage && npm run test:e2e",
@@ -27,7 +29,8 @@
     "matrix-js-sdk": "^37.5.0",
     "nuxt": "^4.3.1",
     "vue": "^3.5.28",
-    "vue-router": "^4.6.4"
+    "vue-router": "^4.6.4",
+    "vue3-recaptcha-v2": "^2.1.0"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^11.0.0",

--- a/tests/e2e/.env.e2e.example
+++ b/tests/e2e/.env.e2e.example
@@ -10,3 +10,6 @@ E2E_MATRIX_PASSWORD=change-me
 # Set by scripts when using docker Synapse+MailHog; see tests/e2e/EMAIL-SIGNUP.md
 # DECENTRA_E2E_SIGNUP_EMAIL=1
 # MAILHOG_API_BASE=http://127.0.0.1:8025
+# Set by scripts when using docker Synapse with registration captcha;
+# see tests/e2e/RECAPTCHA-SIGNUP.md
+# DECENTRA_E2E_SIGNUP_RECAPTCHA=1

--- a/tests/e2e/EMAIL-SIGNUP.md
+++ b/tests/e2e/EMAIL-SIGNUP.md
@@ -26,9 +26,13 @@ Cucumber scenarios tagged `@email_signup`. Synapse is configured with
    `http://127.0.0.1:8025`, use the link in the message, then finish at
    `/signup/verify-email` in the same browser session.
 
-## Default E2E vs email E2E
+## Default E2E vs optional signup suites
 
-- `npm run test:e2e` uses `cucumber-js` with `--tags "not @email_signup"`
-  so MailHog scenarios are excluded.
-- Email flows are only run via `test:e2e:signup-email` or
-  `test:e2e:run:email` (with Synapse already up and configured for email).
+- `npm run test:e2e` uses `cucumber-js` with
+  `--tags "not @email_signup and not @recaptcha_signup"` so MailHog and
+  optional captcha-heavy scenarios stay out of the default lane.
+- Email flows run via `test:e2e:signup-email` or `test:e2e:run:email`
+  (Synapse configured for 3pid email).
+- reCAPTCHA flows run via `test:e2e:signup-recaptcha` or
+  `test:e2e:run:recaptcha` (Synapse `enable_registration_captcha` with
+  Google test keys); see `tests/e2e/RECAPTCHA-SIGNUP.md`.

--- a/tests/e2e/RECAPTCHA-SIGNUP.md
+++ b/tests/e2e/RECAPTCHA-SIGNUP.md
@@ -1,0 +1,33 @@
+# reCAPTCHA sign-up E2E (Issue 57)
+
+## What it does
+
+`npm run test:e2e:signup-recaptcha` starts Docker Synapse with
+`enable_registration_captcha` and Google's **always-pass test keys**, seeds
+users, builds Nuxt, runs the preview server, and executes Cucumber scenarios
+tagged `@recaptcha_signup`.
+
+## Prerequisites
+
+- Docker Desktop (or compatible engine)
+- Ports `8008`, `3000` free
+- First run after toggling captcha overrides may need a clean
+  `tests/e2e/synapse/data` (delete the folder and let
+  `runtime-manage-synapse.mjs up` regenerate `homeserver.yaml`), same as
+  email mode.
+
+## Manual smoke (optional)
+
+1. `cross-env DECENTRA_E2E_SIGNUP_RECAPTCHA=1 node tests/e2e/scripts/runtime-manage-synapse.mjs up`
+2. `node tests/e2e/scripts/runtime-seed-synapse.mjs`
+3. `npm run dev` (or preview on 3000)
+4. Open `http://localhost:3000/signup`, homeserver `http://127.0.0.1:8008`,
+   unique username/password/email.
+5. Complete consent on the captcha step, then solve the v2 widget (test keys).
+
+## Combining with email 3pid
+
+Set **both** `DECENTRA_E2E_SIGNUP_EMAIL=1` and
+`DECENTRA_E2E_SIGNUP_RECAPTCHA=1` before `runtime-manage-synapse.mjs up` to
+inject captcha lines into the MailHog Synapse profile as well (custom
+scenarios).

--- a/tests/e2e/features/signup-recaptcha.feature
+++ b/tests/e2e/features/signup-recaptcha.feature
@@ -1,0 +1,11 @@
+Feature: Signup with reCAPTCHA (Synapse UIA)
+  Covers self-registration when Synapse enables registration captcha.
+  Run with `npm run test:e2e:signup-recaptcha` (Docker required).
+
+  @recaptcha_signup
+  Scenario: Open registration completes after reCAPTCHA step
+    Given I open the signup page for recaptcha e2e
+    When I submit signup against captcha-enabled synapse
+    Then I should see the signup captcha step
+    When I consent and solve the signup recaptcha challenge
+    Then I should land on login after captcha signup success

--- a/tests/e2e/scripts/run-cucumber-recaptcha-only.mjs
+++ b/tests/e2e/scripts/run-cucumber-recaptcha-only.mjs
@@ -13,7 +13,7 @@ function run() {
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(
       'npx',
-      ['cucumber-js', '--tags', 'not @email_signup and not @recaptcha_signup'],
+      ['cucumber-js', '--tags', '@recaptcha_signup'],
       {
         cwd: workspaceRoot,
         stdio: 'inherit',

--- a/tests/e2e/scripts/run-synapse-e2e-signup-recaptcha.mjs
+++ b/tests/e2e/scripts/run-synapse-e2e-signup-recaptcha.mjs
@@ -1,0 +1,90 @@
+import { spawn } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const currentFilePath = fileURLToPath(import.meta.url)
+const workspaceRoot = resolve(dirname(currentFilePath), '..', '..', '..')
+
+function runCommand(binary, args) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const commandProcess = spawn(binary, args, {
+      cwd: workspaceRoot,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+      env: { ...process.env, DECENTRA_E2E_SIGNUP_RECAPTCHA: '1' }
+    })
+    commandProcess.on('error', (error) => rejectPromise(error))
+    commandProcess.on('close', (exitCode) => {
+      if (exitCode === 0) {
+        resolvePromise()
+        return
+      }
+      rejectPromise(
+        new Error(`${binary} exited with code ${exitCode ?? 1}`)
+      )
+    })
+  })
+}
+
+/**
+ * E2E with Synapse registration captcha (Google test keys), then Cucumber
+ * scenarios tagged @recaptcha_signup. Requires Docker.
+ */
+async function main() {
+  let testFailed = false
+  await runCommand('node', [
+    'tests/e2e/scripts/runtime-manage-synapse.mjs',
+    'up'
+  ])
+  await runCommand('node', [
+    'tests/e2e/scripts/runtime-seed-synapse.mjs'
+  ])
+  try {
+    await runCommand('npm', ['run', 'test:e2e:run:recaptcha'])
+  } catch (error) {
+    testFailed = true
+    console.error(
+      error instanceof Error ? error.message : String(error)
+    )
+  } finally {
+    try {
+      if (testFailed) {
+        await runCommand('node', [
+          'tests/e2e/scripts/runtime-manage-synapse.mjs',
+          'logs'
+        ])
+      }
+    } finally {
+      await runCommand('node', [
+        'tests/e2e/scripts/runtime-manage-synapse.mjs',
+        'down'
+      ])
+    }
+  }
+  if (testFailed) {
+    process.exit(1)
+  }
+}
+
+void main().catch(async (error) => {
+  console.error(
+    error instanceof Error ? error.message : String(error)
+  )
+  try {
+    await runCommand('node', [
+      'tests/e2e/scripts/runtime-manage-synapse.mjs',
+      'logs'
+    ])
+  } catch {
+    // Ignore
+  }
+  try {
+    await runCommand('node', [
+      'tests/e2e/scripts/runtime-manage-synapse.mjs',
+      'down'
+    ])
+  } catch {
+    // Ignore
+  }
+  process.exit(1)
+})

--- a/tests/e2e/scripts/runtime-manage-synapse.mjs
+++ b/tests/e2e/scripts/runtime-manage-synapse.mjs
@@ -57,7 +57,8 @@ const rateLimitOverrideLines = [
   '  burst_count: 1000'
 ]
 
-function buildDefaultOverrideBlock() {
+/** @param {string[]} recaptchaLines */
+function buildDefaultOverrideBlock(recaptchaLines) {
   return [
     overrideStart,
     'enable_registration: true',
@@ -65,12 +66,14 @@ function buildDefaultOverrideBlock() {
     'registration_shared_secret: "decentra-e2e-shared-secret"',
     'allow_public_rooms_without_auth: true',
     'allow_public_rooms_over_federation: false',
+    ...recaptchaLines,
     ...rateLimitOverrideLines,
     overrideEnd
   ].join('\n')
 }
 
-function buildEmail3pidOverrideBlock() {
+/** @param {string[]} recaptchaLines */
+function buildEmail3pidOverrideBlock(recaptchaLines) {
   return [
     overrideStart,
     'enable_registration: true',
@@ -85,6 +88,7 @@ function buildEmail3pidOverrideBlock() {
     '  smtp_port: 1025',
     '  notif_from: "Decentra E2E <synapse@localhost>"',
     '  enable_notifs: false',
+    ...recaptchaLines,
     ...rateLimitOverrideLines,
     overrideEnd
   ].join('\n')
@@ -98,9 +102,20 @@ function ensureSynapseConfigOverrides() {
   const useEmail3pid = parseBoolean(
     process.env.DECENTRA_E2E_SIGNUP_EMAIL
   )
+  const useRecaptcha = parseBoolean(
+    process.env.DECENTRA_E2E_SIGNUP_RECAPTCHA
+  )
+  const recaptchaLines = useRecaptcha
+    ? [
+      'enable_registration_captcha: true',
+      // Google's documented always-pass test keys (dev only).
+      'recaptcha_public_key: "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"',
+      'recaptcha_private_key: "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"'
+    ]
+    : []
   const overrideBlock = useEmail3pid
-    ? buildEmail3pidOverrideBlock()
-    : buildDefaultOverrideBlock()
+    ? buildEmail3pidOverrideBlock(recaptchaLines)
+    : buildDefaultOverrideBlock(recaptchaLines)
   const overrideRegex = new RegExp(
     `${overrideStart}[\\s\\S]*${overrideEnd}`,
     'm'
@@ -114,6 +129,12 @@ function ensureSynapseConfigOverrides() {
   if (useEmail3pid) {
     console.log(
       'Synapse E2E: email+3pid overrides (DECENTRA_E2E_SIGNUP_EMAIL=1)'
+    )
+  }
+  if (useRecaptcha) {
+    console.log(
+      'Synapse E2E: registration captcha ' +
+      '(DECENTRA_E2E_SIGNUP_RECAPTCHA=1)'
     )
   }
 }

--- a/tests/e2e/step-definitions/signup-recaptcha.steps.mjs
+++ b/tests/e2e/step-definitions/signup-recaptcha.steps.mjs
@@ -1,0 +1,66 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000'
+const E2E_HS = process.env.E2E_LOCAL_HOMESERVER || 'http://127.0.0.1:8008'
+const E2E_PASSWORD = process.env.E2E_SIGNUP_PASSWORD || 'E2eSignup!Pass9z'
+
+Given('I open the signup page for recaptcha e2e', async function () {
+  await this.page.goto(`${BASE_URL}/signup`, {
+    waitUntil: 'domcontentloaded'
+  })
+})
+
+When('I submit signup against captcha-enabled synapse', async function () {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  this.signupEmail = `e2e-${unique}@localhost`
+  this.signupLocalpart = `e2erc${unique.replace(/[^a-z0-9]/gi, 'x')}`
+    .slice(0, 20)
+  await this.page.getByLabel(/Email|E-Mail/i).first()
+    .fill(this.signupEmail)
+  await this.page.getByLabel(/Homeserver|Homeserver-URL/i).first()
+    .fill(E2E_HS)
+  await this.page.getByLabel(/Username|Benutzername/i).first()
+    .fill(this.signupLocalpart)
+  await this.page.getByLabel(/Password|Passwort/i).first()
+    .fill(E2E_PASSWORD)
+  await this.page.getByRole('button', { name: /Sign up|Registrieren/i })
+    .last()
+    .click()
+})
+
+Then('I should see the signup captcha step', async function () {
+  await expect(
+    this.page.getByRole('heading', {
+      name: /Verify you are human|Bestaetigung gegen Bots|Mensch/i
+    })
+  ).toBeVisible({ timeout: 120000 })
+})
+
+When('I consent and solve the signup recaptcha challenge', async function () {
+  await this.page.getByRole('button', {
+    name: /Agree and load reCAPTCHA|Zustimmen und reCAPTCHA laden/i
+  }).click()
+  const anchorSelector = 'iframe[src*="google.com/recaptcha/api2/anchor"]'
+  await this.page.locator(anchorSelector).first().waitFor({
+    state: 'visible',
+    timeout: 90000
+  })
+  const anchorFrame = this.page.frameLocator(anchorSelector).first()
+  await anchorFrame.locator('#recaptcha-anchor').click({
+    timeout: 90000
+  })
+})
+
+Then('I should land on login after captcha signup success', async function () {
+  await this.page.waitForURL(
+    (url) => {
+      return url.pathname === '/login' &&
+        url.searchParams.get('signup') === 'success'
+    },
+    { timeout: 120000 }
+  )
+  await expect(
+    this.page.getByText(/Account created|Konto erstellt/i)
+  ).toBeVisible({ timeout: 30000 })
+})

--- a/tests/unit/composables/matrixRegistrationUia.spec.ts
+++ b/tests/unit/composables/matrixRegistrationUia.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildRecaptchaAuthPayload,
+  extractRecaptchaFromParams,
+  RECAPTCHA_STAGE
+} from '~/composables/matrix/matrixRegistrationUia'
+
+describe('matrixRegistrationUia', () => {
+  describe('extractRecaptchaFromParams', () => {
+    it('returns site key from Synapse-style params', () => {
+      const params: Record<string, unknown> = {
+        [RECAPTCHA_STAGE]: {
+          public_key: ' pk-test ',
+          version: 'v2'
+        }
+      }
+      const parsed = extractRecaptchaFromParams(params)
+      expect(parsed?.siteKey).toBe('pk-test')
+      expect(parsed?.version).toBe('v2')
+    })
+
+    it('defaults to v2 when version omitted', () => {
+      const params: Record<string, unknown> = {
+        [RECAPTCHA_STAGE]: {
+          public_key: 'pk-default'
+        }
+      }
+      expect(extractRecaptchaFromParams(params)?.version).toBe('v2')
+    })
+
+    it('detects v3 hint', () => {
+      const params: Record<string, unknown> = {
+        [RECAPTCHA_STAGE]: {
+          public_key: 'pk-v3',
+          version: 'v3'
+        }
+      }
+      expect(extractRecaptchaFromParams(params)?.version).toBe('v3')
+    })
+
+    it('returns null when block missing', () => {
+      expect(extractRecaptchaFromParams({})).toBeNull()
+      expect(extractRecaptchaFromParams(undefined)).toBeNull()
+    })
+  })
+
+  describe('buildRecaptchaAuthPayload', () => {
+    it('includes Matrix UIA auth shape', () => {
+      const payload = buildRecaptchaAuthPayload('sess-1', 'tok')
+      expect(payload).toEqual({
+        type: RECAPTCHA_STAGE,
+        session: 'sess-1',
+        response: 'tok'
+      })
+    })
+  })
+})

--- a/tests/unit/pages/signup-verify-email.spec.ts
+++ b/tests/unit/pages/signup-verify-email.spec.ts
@@ -3,10 +3,25 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { ref } from 'vue'
 import VerifyPage from '~/pages/signup/verify-email.vue'
 
-const { navigateToMock, finalizeMock } = vi.hoisted(() => {
+const {
+  navigateToMock,
+  finalizeMock,
+  readSignupPendingPublicMock,
+  extractRecaptchaFromParamsMock,
+  PENDING_KEY
+} = vi.hoisted(() => {
   return {
     navigateToMock: vi.fn(async () => undefined),
-    finalizeMock: vi.fn(async () => undefined)
+    finalizeMock: vi.fn(async () => undefined),
+    readSignupPendingPublicMock: vi.fn(() => null as Record<
+      string,
+      unknown
+    > | null),
+    extractRecaptchaFromParamsMock: vi.fn(() => null as {
+      siteKey: string
+      version: 'v2' | 'v3'
+    } | null),
+    PENDING_KEY: 'decentra.signup.pending.v1'
   }
 })
 
@@ -26,7 +41,11 @@ vi.mock('~/composables/useAppI18n', () => {
           'auth.signUpUnavailable': 'Unavailable',
           'auth.homeserverConnectionHint': 'Hint',
           'auth.signUpUnsupportedAuthStage': 'Unsupported',
-          'auth.signUpSessionExpired': 'Expired'
+          'auth.signUpSessionExpired': 'Expired',
+          'auth.signUpCaptchaTitle': 'Verify you are human',
+          'auth.signUpRecaptchaFailed': 'reCAPTCHA failed',
+          'auth.signUpRecaptchaRequired': 'reCAPTCHA required',
+          'auth.signUpRecaptchaMissingSiteKey': 'Missing site key'
         }
         return messages[key] ?? key
       }
@@ -45,6 +64,11 @@ vi.mock('~/composables/useMatrixClient', () => {
     HOMESERVER_CONNECTION_HINT_ERROR: 'HOMESERVER_CONNECTION_HINT',
     SIGNUP_REGISTRATION_UNSUPPORTED_STAGE:
       'SIGNUP_REGISTRATION_UNSUPPORTED_STAGE',
+    SIGNUP_RECAPTCHA_FAILED: 'SIGNUP_RECAPTCHA_FAILED',
+    SIGNUP_RECAPTCHA_TOKEN_REQUIRED: 'SIGNUP_RECAPTCHA_TOKEN_REQUIRED',
+    SIGNUP_PENDING_STORAGE_KEY: PENDING_KEY,
+    readSignupPendingPublic: readSignupPendingPublicMock,
+    extractRecaptchaFromParams: extractRecaptchaFromParamsMock,
     useMatrixClient: () => ({ isLoggedIn: ref(false) }),
     finalizeEmailRegistration: finalizeMock
   }
@@ -73,10 +97,19 @@ const NuxtLinkStub = {
   template: '<a><slot /></a>'
 }
 
+const SignupRecaptchaStepStub = {
+  props: ['siteKey', 'version'],
+  emits: ['verified'],
+  template:
+    '<button type="button" class="mock-verify" @click="$emit(\'verified\', \'tok\')">Verify captcha</button>'
+}
+
 describe('signup verify-email page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     finalizeMock.mockResolvedValue(undefined)
+    readSignupPendingPublicMock.mockReturnValue(null)
+    extractRecaptchaFromParamsMock.mockReturnValue(null)
     ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
   })
 
@@ -87,7 +120,8 @@ describe('signup verify-email page', () => {
           UCard: UCardStub,
           UAlert: UAlertStub,
           UButton: UButtonStub,
-          NuxtLink: NuxtLinkStub
+          NuxtLink: NuxtLinkStub,
+          SignupRecaptchaStep: SignupRecaptchaStepStub
         }
       }
     })
@@ -110,7 +144,9 @@ describe('signup verify-email page', () => {
     const wrapper = mountVerify()
     await flushPromises()
     expect(wrapper.text().includes('Not confirmed yet')).toBe(true)
-    const retry = wrapper.findAll('button').find((b) => b.text().includes('Retry'))
+    const retry = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Retry'))
     expect(retry).toBeDefined()
     const beforeRetry = finalizeMock.mock.calls.length
     await retry!.trigger('click')
@@ -127,5 +163,41 @@ describe('signup verify-email page', () => {
     const wrapper = mountVerify()
     await flushPromises()
     expect(wrapper.text().includes('No pending')).toBe(true)
+  })
+
+  it('shows captcha when finalize requires token', async () => {
+    readSignupPendingPublicMock.mockReturnValue({
+      recaptchaSiteKey: 'site-x',
+      recaptchaVersion: 'v2'
+    })
+    finalizeMock.mockRejectedValueOnce(
+      new Error('SIGNUP_RECAPTCHA_TOKEN_REQUIRED')
+    )
+    const wrapper = mountVerify()
+    await flushPromises()
+    expect(wrapper.text().includes('Verify you are human')).toBe(true)
+    const captchaBtn = wrapper.find('.mock-verify')
+    expect(captchaBtn.exists()).toBe(true)
+    finalizeMock.mockResolvedValueOnce(undefined)
+    await captchaBtn.trigger('click')
+    await flushPromises()
+    expect(finalizeMock).toHaveBeenLastCalledWith({
+      recaptchaResponse: 'tok'
+    })
+    expect(navigateToMock).toHaveBeenCalledWith({
+      path: '/login',
+      query: { signup: 'success' }
+    })
+  })
+
+  it('shows error when captcha needed but site key missing', async () => {
+    readSignupPendingPublicMock.mockReturnValue({})
+    extractRecaptchaFromParamsMock.mockReturnValue(null)
+    finalizeMock.mockRejectedValueOnce(
+      new Error('SIGNUP_RECAPTCHA_TOKEN_REQUIRED')
+    )
+    const wrapper = mountVerify()
+    await flushPromises()
+    expect(wrapper.text().includes('Missing site key')).toBe(true)
   })
 })

--- a/tests/unit/pages/signup.spec.ts
+++ b/tests/unit/pages/signup.spec.ts
@@ -6,14 +6,54 @@ import SignupPage from '~/pages/signup.vue'
 const {
   navigateToMock,
   startEmailRegistrationMock,
+  submitSignupRecaptchaMock,
   PENDING_KEY
 } = vi.hoisted(() => {
   return {
     navigateToMock: vi.fn(async () => undefined),
     startEmailRegistrationMock: vi.fn(async () => undefined),
+    submitSignupRecaptchaMock: vi.fn(async () => undefined),
     PENDING_KEY: 'decentra.signup.pending.v1'
   }
 })
+
+function mockExtractRecaptchaFromParams(
+  params?: Record<string, unknown>
+): { siteKey: string; version: 'v2' | 'v3' } | null {
+  if (!params || typeof params !== 'object') {
+    return null
+  }
+  const blockUnknown = params['m.login.recaptcha']
+  if (!blockUnknown || typeof blockUnknown !== 'object') {
+    return null
+  }
+  const block = blockUnknown as Record<string, unknown>
+  const publicKey = block.public_key
+  if (typeof publicKey !== 'string' || !publicKey.trim()) {
+    return null
+  }
+  let version: 'v2' | 'v3' = 'v2'
+  const rawVersion = block.version
+  if (rawVersion === 'v3' || rawVersion === 3) {
+    version = 'v3'
+  }
+  return { siteKey: publicKey.trim(), version }
+}
+
+function mockReadSignupPendingPublic(): Record<string, unknown> | null {
+  if (typeof sessionStorage === 'undefined') {
+    return null
+  }
+  const raw = sessionStorage.getItem(PENDING_KEY)
+  if (!raw) {
+    return null
+  }
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
 
 vi.mock('~/composables/useAppI18n', () => {
   return {
@@ -27,7 +67,8 @@ vi.mock('~/composables/useAppI18n', () => {
           'auth.username': 'Username',
           'auth.password': 'Password',
           'auth.signUpFailed': 'Sign up failed',
-          'auth.signUpUnavailable': 'Sign-up is not available on this homeserver',
+          'auth.signUpUnavailable':
+            'Sign-up is not available on this homeserver',
           'auth.signUpEmailVerificationRequired':
             'Sign-up requires email verification on this homeserver',
           'auth.homeserverConnectionHint': 'Connection hint',
@@ -38,7 +79,16 @@ vi.mock('~/composables/useAppI18n', () => {
           'auth.signUpEmailNotConfirmedYet': 'Not confirmed',
           'auth.signUpPendingMissing': 'No pending',
           'auth.signUpSessionExpired': 'Session expired',
-          'auth.signUpUnsupportedAuthStage': 'Unsupported'
+          'auth.signUpUnsupportedAuthStage': 'Unsupported',
+          'auth.signUpCaptchaTitle': 'Verify you are human',
+          'auth.signUpRecaptchaMissingSiteKey': 'Missing site key',
+          'auth.signUpRecaptchaFailed': 'reCAPTCHA failed',
+          'auth.signUpCaptchaConsentLead': 'Consent lead',
+          'auth.signUpHomeserverPrivacyNotice': 'Homeserver notice',
+          'auth.signUpPrivacyPolicyLink': 'Privacy',
+          'auth.signUpCookieSettings': 'Cookies',
+          'auth.signUpAgreeLoadRecaptcha': 'Agree load',
+          'auth.signUpRunRecaptchaCheck': 'Run check'
         }
         return messages[key] ?? key
       }
@@ -51,7 +101,16 @@ vi.mock('~/composables/useMatrixClient', () => {
     SIGNUP_UNAVAILABLE_ERROR: 'SIGNUP_UNAVAILABLE',
     SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR:
       'SIGNUP_EMAIL_VERIFICATION_REQUIRED',
+    SIGNUP_PENDING_MISSING: 'SIGNUP_PENDING_MISSING',
+    SIGNUP_RECAPTCHA_FAILED: 'SIGNUP_RECAPTCHA_FAILED',
     SIGNUP_PENDING_STORAGE_KEY: PENDING_KEY,
+    HOMESERVER_CONNECTION_HINT_ERROR: 'HOMESERVER_CONNECTION_HINT',
+    SIGNUP_EMAIL_NOT_CONFIRMED_YET: 'SIGNUP_EMAIL_NOT_CONFIRMED_YET',
+    SIGNUP_REGISTRATION_UNSUPPORTED_STAGE:
+      'SIGNUP_REGISTRATION_UNSUPPORTED_STAGE',
+    SIGNUP_SESSION_EXPIRED: 'SIGNUP_SESSION_EXPIRED',
+    extractRecaptchaFromParams: mockExtractRecaptchaFromParams,
+    readSignupPendingPublic: mockReadSignupPendingPublic,
     clearSignupPending: vi.fn(() => {
       if (typeof sessionStorage !== 'undefined') {
         sessionStorage.removeItem(PENDING_KEY)
@@ -60,7 +119,8 @@ vi.mock('~/composables/useMatrixClient', () => {
     useMatrixClient: () => ({
       isLoggedIn: ref(false)
     }),
-    startEmailRegistration: startEmailRegistrationMock
+    startEmailRegistration: startEmailRegistrationMock,
+    submitSignupRecaptcha: submitSignupRecaptchaMock
   }
 })
 
@@ -89,9 +149,9 @@ const UAlertStub = {
 }
 
 const UButtonStub = {
-  props: ['type'],
+  props: ['type', 'disabled', 'loading', 'to'],
   template: `
-    <button :type="type || 'button'">
+    <button :type="type || 'button'" :disabled="disabled">
       <slot />
     </button>
   `
@@ -101,6 +161,15 @@ const NuxtLinkStub = {
   template: '<a><slot /></a>'
 }
 
+const ClientOnlyStub = {
+  template: '<span><slot /></span>'
+}
+
+const SignupRecaptchaStepStub = {
+  props: ['siteKey', 'version'],
+  template: '<div class="recaptcha-stub">stub</div>'
+}
+
 describe('signup page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -108,6 +177,7 @@ describe('signup page', () => {
       sessionStorage.clear()
     }
     startEmailRegistrationMock.mockImplementation(async () => undefined)
+    submitSignupRecaptchaMock.mockImplementation(async () => undefined)
     ;(globalThis as Record<string, unknown>).navigateTo = navigateToMock
   })
 
@@ -120,7 +190,9 @@ describe('signup page', () => {
           UInput: UInputStub,
           UAlert: UAlertStub,
           UButton: UButtonStub,
-          NuxtLink: NuxtLinkStub
+          NuxtLink: NuxtLinkStub,
+          ClientOnly: ClientOnlyStub,
+          SignupRecaptchaStep: SignupRecaptchaStepStub
         }
       }
     })
@@ -176,6 +248,37 @@ describe('signup page', () => {
     await passwordInput!.setValue('secret')
     await wrapper.find('form').trigger('submit.prevent')
     expect(wrapper.text().includes('Check your email'))
+      .toBe(true)
+    expect(navigateToMock).not.toHaveBeenCalled()
+  })
+
+  it('shows captcha panel when homeserver requires captcha before email', async () => {
+    startEmailRegistrationMock.mockImplementation(async () => {
+      sessionStorage.setItem(
+        PENDING_KEY,
+        JSON.stringify({
+          v: 1,
+          baseUrl: 'https://matrix.example.org',
+          needsRecaptchaBeforeEmail: true,
+          recaptchaSiteKey: 'test-site-key',
+          recaptchaVersion: 'v2'
+        })
+      )
+    })
+    const wrapper = mountSignupPage()
+    const inputElements = wrapper.findAll('input')
+    const [
+      emailInput,
+      homeserverInput,
+      usernameInput,
+      passwordInput
+    ] = inputElements
+    await emailInput!.setValue('alice@example.org')
+    await homeserverInput!.setValue('https://matrix.example.org')
+    await usernameInput!.setValue('alice')
+    await passwordInput!.setValue('secret')
+    await wrapper.find('form').trigger('submit.prevent')
+    expect(wrapper.text().includes('Verify you are human'))
       .toBe(true)
     expect(navigateToMock).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
- Introduce a new reCAPTCHA UIA stage (`m.login.recaptcha`) for user signup, enhancing security with consent-gated script loading and optional iubenda hooks.
- Add optional Synapse-backed E2E for registration captcha, documented in `tests/e2e/RECAPTCHA-SIGNUP.md`.
- Create a new `SignupRecaptchaStep` component for handling reCAPTCHA verification during signup.
- Update `useMatrixClient` and related composables to manage reCAPTCHA state and responses.
- Enhance translations in `useAppI18n` for reCAPTCHA-related messages in both English and German.
- Update CHANGELOG to reflect the addition of reCAPTCHA functionality and related enhancements.