### PR TITLE
Enhance signup process with registration token and terms acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SMTP to MailHog), Cucumber scenarios tagged `@email_signup`, helper
   runners to exclude that tag in default E2E, `test:e2e:signup-email` full
   pipeline script, and `tests/e2e/EMAIL-SIGNUP.md` notes
+- Extended Matrix signup UIA (#58): `m.login.registration_token`
+  (including `*.login.registration_token` ids), `m.login.terms` with
+  `SignupTermsStep.vue`, shortest completable email-flow selection, chained
+  pre-email stages on `/signup` and `/signup/verify-email`
+- User-facing SSO-only registration hint (`SIGNUP_SSO_USE_WEB_CLIENT`)
+  and explicit SMS signup non-support (`SIGNUP_MSISDN_NOT_SUPPORTED`)
+  (#58)
+- Additional unit coverage for registration UIA helpers and signup pages
+  (`matrixRegistrationUia.spec.ts`, page specs)
 
 ### Changed
 
@@ -101,7 +110,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Room navigation supports home categories for personal/unassigned rooms
 - Chat shell styling refined with distinct visual background accents
 - Read receipts now show smaller avatars on each reader's last-read message
-- README extended with CI and E2E credential setup documentation
+- README: CI/E2E credential setup; Matrix registration (UIA) section and
+  signup-related structure paths; phased roadmap bullets removed—priorities
+  in GitHub Issues; status line shortened
 - Message list rendering was modularized with a dedicated `ChatMessageItem`
   component and reusable `ChatMessageActionBar`
 - Full CI lane now runs E2E against local Dockerized Synapse instead of

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Matrix-based chat client with Spaces, Categories, and Rooms.
 
-**Status:** Alpha (v0.1.0) – Phase 2 completed, Phase 3 in planning.
+**Status:** Alpha (v0.1.0). Priorities follow GitHub Issues for this repo.
 
 ## Tech Stack
 
@@ -115,9 +115,12 @@ tests (`setupTest()`, plugin/runtime integration, Nitro route tests).
 
 ```
 app/
-├── composables/useMatrixClient.ts   # Matrix login, sync, rooms, messages
+├── composables/useMatrixClient.ts           # Login, crypto, sync, messaging
+├── composables/matrix/matrixRegistrationUia.ts
+│                                              # Email signup UIA loop
 ├── pages/
-│   ├── login.vue
+│   ├── login.vue / signup.vue
+│   ├── signup/verify-email.vue
 │   ├── chat.vue
 │   └── index.vue
 └── components/Chat/
@@ -126,13 +129,37 @@ app/
     └── MessageInput.vue
 ```
 
-## Roadmap
+## Matrix registration (UIA)
 
-- **Phase 1:** Login, Rooms, Chat, Messages
-- **Phase 2:** Four-column layout (Spaces | Categories/Rooms | Chat | Members)
-- **Phase 3 (current):** Voice, E2E encryption, favorites, and space grouping
-- **Phase 4:** Design system and selectable themes
-- **Phase 5:** Native clients (Windows, Linux, Android)
+Signup uses Matrix **User-Interactive Authentication** against
+`/register`: first request may return **401** with `session`, `flows`,
+and `params`; the client keeps the session and completes stages in order.
+
+**Supported stages today**
+
+| Stage | Notes |
+| --- | --- |
+| `m.login.email.identity` | Email verification link; continuation on `/signup/verify-email` |
+| `m.login.recaptcha` | reCAPTCHA v2/v3 from homeserver params |
+| `m.login.registration_token` | Opaque token; unstable ids ending in `.login.registration_token` treated the same |
+| `m.login.terms` | Policy links from `params`; user accepts before continuing |
+| `m.login.dummy` | Included in finalize loop when required by the server |
+
+**Explicit non-support**
+
+- **`m.login.sso`** – SSO/OIDC signup is not implemented in-app. Users see a
+  message to complete registration via a Matrix web client (e.g. Element),
+  then sign in here.
+- **`m.login.msisdn`** – Phone/SMS registration is not implemented; users get
+  a clear “not supported” message instead of failing silently.
+
+When several flows include email verification, Decentra picks a **shortest**
+flow whose stages are all supported.
+
+**Locations:** `matrixRegistrationUia.ts` (logic), `signup.vue` /
+`signup/verify-email.vue` + `SignupTermsStep.vue` (UI).  
+**Regression tests:** `npm run test:unit` (see `tests/unit/composables/matrixRegistrationUia.spec.ts`
+and signup page specs).
 
 ## License
 

--- a/app/components/auth/SignupTermsStep.vue
+++ b/app/components/auth/SignupTermsStep.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import type { SignupTermsPolicyItem } from '~/composables/matrix/matrixRegistrationUia'
+import { computed, ref } from 'vue'
+import { useAppI18n } from '~/composables/useAppI18n'
+
+const props = defineProps<{
+  policies: SignupTermsPolicyItem[]
+}>()
+
+const emit = defineEmits<{
+  continue: []
+}>()
+
+const consent = ref(false)
+const { translateText } = useAppI18n()
+
+const canProceed = computed(() => {
+  return consent.value &&
+    props.policies.length > 0
+})
+
+function onContinue(): void {
+  if (canProceed.value) {
+    emit('continue')
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <p
+      v-if="policies.length === 0"
+      class="text-sm text-gray-600 dark:text-gray-300"
+    >
+      {{ translateText('auth.signUpTermsEmptyPolicies') }}
+    </p>
+    <ul
+      v-else
+      class="space-y-3 text-sm"
+    >
+      <li
+        v-for="item in policies"
+        :key="item.policyId + item.version"
+        class="rounded border border-gray-200/70 p-3 dark:border-gray-700"
+      >
+        <a
+          :href="item.url"
+          class="font-medium text-sky-500 underline underline-offset-2 hover:text-sky-400"
+          target="_blank"
+          rel="noopener noreferrer"
+          :title="item.url"
+        >
+          {{ item.name }}
+        </a>
+      </li>
+    </ul>
+    <UCheckbox
+      v-if="policies.length > 0"
+      v-model="consent"
+      :disabled="policies.length === 0"
+    >
+      {{ translateText('auth.signUpTermsAcceptCheckbox') }}
+    </UCheckbox>
+    <UButton
+      class="w-full justify-center"
+      :disabled="!canProceed"
+      @click="onContinue"
+    >
+      {{ translateText('auth.signUpTermsContinue') }}
+    </UButton>
+  </div>
+</template>

--- a/app/composables/matrix/matrixRegistrationUia.ts
+++ b/app/composables/matrix/matrixRegistrationUia.ts
@@ -23,10 +23,26 @@ export const SIGNUP_REGISTRATION_UNSUPPORTED_STAGE =
 export const SIGNUP_RECAPTCHA_TOKEN_REQUIRED =
   'SIGNUP_RECAPTCHA_TOKEN_REQUIRED'
 export const SIGNUP_RECAPTCHA_FAILED = 'SIGNUP_RECAPTCHA_FAILED'
+export const SIGNUP_SSO_USE_WEB_CLIENT = 'SIGNUP_SSO_USE_WEB_CLIENT'
+export const SIGNUP_MSISDN_NOT_SUPPORTED = 'SIGNUP_MSISDN_NOT_SUPPORTED'
+export const SIGNUP_REGISTRATION_TOKEN_REQUIRED =
+  'SIGNUP_REGISTRATION_TOKEN_REQUIRED'
+export const SIGNUP_REGISTRATION_TOKEN_REJECTED =
+  'SIGNUP_REGISTRATION_TOKEN_REJECTED'
+export const SIGNUP_TERMS_ACCEPTANCE_REQUIRED =
+  'SIGNUP_TERMS_ACCEPTANCE_REQUIRED'
 
 export const SIGNUP_PENDING_STORAGE_KEY = 'decentra.signup.pending.v1'
 
 const SIGNUP_PENDING_V = 1
+
+/** Matrix ToS links for signup (serializable subset). */
+export type SignupTermsPolicyItem = {
+  policyId: string
+  version: string
+  name: string
+  url: string
+}
 
 export type SignupPendingStateV1 = {
   v: 1
@@ -35,7 +51,7 @@ export type SignupPendingStateV1 = {
   password: string
   email: string
   clientSecret: string
-  /** Present after Homeserver issued registration email token sid */
+  /** Present after HS issued registration email token sid */
   sid: string
   session: string
   initialSession: string
@@ -45,6 +61,16 @@ export type SignupPendingStateV1 = {
   recaptchaVersion?: 'v2' | 'v3'
   /** True while user must solve captcha before email token request */
   needsRecaptchaBeforeEmail?: boolean
+  /** True while user must enter registration token before email token */
+  needsRegistrationTokenBeforeEmail?: boolean
+  /** True until user accepts ToS/policy links */
+  needsTermsAcceptanceBeforeEmail?: boolean
+  /** Snapshot for terms UI while {@link needsTermsAcceptanceBeforeEmail} */
+  termsPoliciesSnapshot?: SignupTermsPolicyItem[]
+  /** User-supplied opaque token when required mid-flow */
+  registrationTokenDraft?: string
+  /** Server `completed` UIA rounds (latest known snapshot) */
+  completedStagesSnapshot?: string[]
 }
 
 function createRegisterEmailClientSecret(): string {
@@ -61,6 +87,11 @@ function createRegisterEmailClientSecret(): string {
 const EMAIL_IDENTITY_STAGE = 'm.login.email.identity'
 const DUMMY_STAGE = 'm.login.dummy'
 export const RECAPTCHA_STAGE = 'm.login.recaptcha'
+
+export const REGISTRATION_TOKEN_STAGE = 'm.login.registration_token'
+export const TERMS_STAGE = 'm.login.terms'
+const SSO_STAGE = 'm.login.sso'
+const MSISDN_STAGE = 'm.login.msisdn'
 
 interface MatrixUiaData {
   session?: string
@@ -89,6 +120,101 @@ function readMatrixUiaData(error: unknown): MatrixUiaData | null {
   }
 }
 
+/** Registration token MSC stage aliases (homeserver-provided literal). */
+export function isRegistrationTokenStage(stage: string): boolean {
+  if (!stage.trim()) {
+    return false
+  }
+  if (stage === REGISTRATION_TOKEN_STAGE) {
+    return true
+  }
+  const lower = stage.toLowerCase()
+  return lower.endsWith('.login.registration_token')
+}
+
+/** Terms stage identifiers (usually stable identifier). */
+export function isTermsStage(stage: string): boolean {
+  if (!stage.trim()) {
+    return false
+  }
+  if (stage === TERMS_STAGE) {
+    return true
+  }
+  return stage.toLowerCase().endsWith('.login.terms')
+}
+
+function isSsoStage(stage: string): boolean {
+  if (!stage.trim()) {
+    return false
+  }
+  if (stage === SSO_STAGE) {
+    return true
+  }
+  const lower = stage.toLowerCase()
+  return lower.includes('.login.sso') || lower === 'm.login.oauth2'
+}
+
+function isMsisdnStage(stage: string): boolean {
+  return stage === MSISDN_STAGE ||
+    stage.toLowerCase().endsWith('.login.msisdn')
+}
+
+function isCompleterSupportedUiStage(stage: string): boolean {
+  if (stage === EMAIL_IDENTITY_STAGE) {
+    return true
+  }
+  if (
+    stage === DUMMY_STAGE ||
+    stage === RECAPTCHA_STAGE ||
+    isTermsStage(stage) ||
+    isRegistrationTokenStage(stage)
+  ) {
+    return true
+  }
+  if (isSsoStage(stage) || isMsisdnStage(stage)) {
+    return false
+  }
+  return false
+}
+
+/**
+ * Finds a signup flow containing email.identity where Decentra can complete
+ * every stage (excluding SSO/OIDC phone-only paths).
+ */
+export function pickCompletableEmailSignupFlow(
+  flows: Array<{ stages?: string[] }> | undefined
+):
+  | { ok: true; stages: string[] }
+  | { ok: false; reason: 'no_email' | 'sso_only' | 'msisdn_block' |
+      'unsupported' }
+{
+  if (!Array.isArray(flows)) {
+    return { ok: false, reason: 'no_email' }
+  }
+  const emailFlows = flows
+    .map((flowEntry) => flowEntry.stages || [])
+    .filter((stages) => stages.includes(EMAIL_IDENTITY_STAGE))
+  if (emailFlows.length === 0) {
+    return { ok: false, reason: 'no_email' }
+  }
+  const completable = emailFlows.filter((stageList) =>
+    stageList.every((stage) => isCompleterSupportedUiStage(stage))
+  )
+  if (completable.length > 0) {
+    completable.sort(
+      (a, b) => a.length - b.length || a.join().localeCompare(b.join())
+    )
+    return { ok: true, stages: completable[0] as string[] }
+  }
+  if (emailFlows.every((stageList) => stageList.some(isSsoStage))) {
+    return { ok: false, reason: 'sso_only' }
+  }
+  if (emailFlows.every((stageList) => stageList.some(isMsisdnStage))) {
+    return { ok: false, reason: 'msisdn_block' }
+  }
+  return { ok: false, reason: 'unsupported' }
+}
+
 /**
  * Parses Synapse/Matrix UIA params for {@link RECAPTCHA_STAGE}.
  */
@@ -115,28 +241,221 @@ export function extractRecaptchaFromParams(
   return { siteKey: publicKey.trim(), version }
 }
 
+/** Collects docs from `params` for matrix `m.login.terms`. */
+export function extractTermsPoliciesFromParams(
+  params: Record<string, unknown> | undefined,
+  preferredLocales: readonly string[]
+): SignupTermsPolicyItem[] {
+  if (!params || typeof params !== 'object') {
+    return []
+  }
+  let policiesBlock: Record<string, unknown> | null = null
+  const direct = params[TERMS_STAGE]
+  if (
+    direct &&
+    typeof direct === 'object' &&
+    !Array.isArray(direct)
+  ) {
+    policiesBlock =
+      extractPoliciesMap(direct as Record<string, unknown>)
+  }
+  if (!policiesBlock) {
+    for (const [, valueUnknown] of Object.entries(params)) {
+      if (
+        valueUnknown &&
+        typeof valueUnknown === 'object' &&
+        !Array.isArray(valueUnknown)
+      ) {
+        const trial = extractPoliciesMap(
+          valueUnknown as Record<string, unknown>
+        )
+        if (trial) {
+          policiesBlock = trial
+          break
+        }
+      }
+    }
+  }
+  if (!policiesBlock) {
+    return []
+  }
+  const locales = preferredLocales
+    .filter((locale) => typeof locale === 'string' && locale.trim())
+    .map((locale) => locale.trim().replace(/_/g, '-'))
+  const out: SignupTermsPolicyItem[] = []
+  for (const [policyId, defUnknown] of Object.entries(policiesBlock)) {
+    if (
+      typeof defUnknown !== 'object' ||
+      defUnknown === null ||
+      Array.isArray(defUnknown)
+    ) {
+      continue
+    }
+    const defRecord = defUnknown as Record<string, unknown>
+    const version =
+      typeof defRecord.version === 'string'
+        ? defRecord.version.trim()
+        : ''
+    let chosenName = ''
+    let chosenUrl = ''
+    for (const locale of locales) {
+      const tryShort = locale.split('-')[0] ?? locale
+      const candidates =
+        locale === tryShort
+          ? [locale]
+          : [locale, tryShort].filter(Boolean) as string[]
+      for (const cand of candidates) {
+        const tr = pickPolicyTranslation(defRecord, cand)
+        if (tr) {
+          chosenName = tr.name
+          chosenUrl = tr.url
+          break
+        }
+      }
+      if (chosenUrl) {
+        break
+      }
+    }
+    if (!chosenUrl) {
+      for (const [, valueMaybe] of Object.entries(defRecord)) {
+        if (valueMaybe === version) {
+          continue
+        }
+        if (
+          valueMaybe &&
+          typeof valueMaybe === 'object' &&
+          !Array.isArray(valueMaybe)
+        ) {
+          const trMaybe = valueMaybe as Record<string, unknown>
+          const n = trMaybe.name
+          const u = trMaybe.url
+          if (typeof u === 'string' && u.trim()) {
+            chosenName = typeof n === 'string' && n.trim()
+              ? n.trim()
+              : policyId
+            chosenUrl = u.trim()
+            break
+          }
+        }
+      }
+    }
+    if (chosenUrl) {
+      out.push({
+        policyId,
+        version: version || '—',
+        name: chosenName || policyId,
+        url: chosenUrl
+      })
+    }
+  }
+  return out
+}
+
+function extractPoliciesMap(
+  block: Record<string, unknown>
+): Record<string, unknown> | null {
+  const direct = block.policies
+  if (
+    direct &&
+    typeof direct === 'object' &&
+    !Array.isArray(direct)
+  ) {
+    return direct as Record<string, unknown>
+  }
+  const keysTop = Object.keys(block)
+  if (
+    keysTop.some((attributeKey) => attributeKey === 'policies')
+  ) {
+    return null
+  }
+  if (keysTop.length > 0) {
+    return block
+  }
+  return null
+}
+
+function pickPolicyTranslation(
+  defRecord: Record<string, unknown>,
+  localeTag: string
+): { name: string; url: string } | null {
+  const trUnknown = defRecord[localeTag]
+  if (
+    trUnknown &&
+    typeof trUnknown === 'object' &&
+    !Array.isArray(trUnknown)
+  ) {
+    const trRecord = trUnknown as Record<string, unknown>
+    const name = typeof trRecord.name === 'string'
+      ? trRecord.name.trim()
+      : ''
+    const url = typeof trRecord.url === 'string'
+      ? trRecord.url.trim()
+      : ''
+    if (url) {
+      return { name: name || localeTag, url }
+    }
+  }
+  const altLocale = localeTag.replace(/-/g, '_')
+  if (altLocale !== localeTag) {
+    return pickPolicyTranslation(defRecord, altLocale)
+  }
+  return null
+}
+
+function preferredSignupLocales(): string[] {
+  if (typeof navigator === 'undefined' || !navigator.language) {
+    return ['en']
+  }
+  const primary = navigator.language
+  const list = navigator.languages?.length
+    ? [...navigator.languages]
+    : [primary]
+  const uniq: string[] = []
+  const seenLower = new Set<string>()
+  for (const locale of list) {
+    const trimmed = locale.trim()
+    const low = trimmed.toLowerCase()
+    if (trimmed && !seenLower.has(low)) {
+      seenLower.add(low)
+      uniq.push(trimmed)
+    }
+  }
+  if (!uniq.includes('en')) {
+    uniq.push('en')
+  }
+  return uniq
+}
+
 export function signupPendingNeedsRecaptchaBeforeEmail(): boolean {
   const pending = readSignupPending()
   return pending?.needsRecaptchaBeforeEmail === true
+}
+
+export function signupPendingNeedsRegistrationTokenBeforeEmail(): boolean {
+  const pending = readSignupPending()
+  return pending?.needsRegistrationTokenBeforeEmail === true
+}
+
+export function signupPendingNeedsTermsBeforeEmail(): boolean {
+  const pending = readSignupPending()
+  return pending?.needsTermsAcceptanceBeforeEmail === true
 }
 
 export function readSignupPendingPublic(): SignupPendingStateV1 | null {
   return readSignupPending()
 }
 
-function pickFlowWithEmail(
-  flows: Array<{ stages?: string[] }> | undefined
-): string[] | null {
-  if (!Array.isArray(flows)) {
-    return null
+export function hydrateTermsPoliciesForPending(): SignupTermsPolicyItem[] {
+  const pending = readSignupPending()
+  const params = pending?.paramsSnapshot
+  const existing = pending?.termsPoliciesSnapshot
+  if (existing?.length) {
+    return existing
   }
-  for (const flow of flows) {
-    const stages = flow.stages || []
-    if (stages.includes(EMAIL_IDENTITY_STAGE)) {
-      return stages
-    }
-  }
-  return null
+  return extractTermsPoliciesFromParams(
+    params,
+    preferredSignupLocales()
+  )
 }
 
 function getNextAuthStage(
@@ -150,6 +469,120 @@ function getNextAuthStage(
     }
   }
   return null
+}
+
+function mergeParamsIntoPending(
+  pending: SignupPendingStateV1,
+  params: Record<string, unknown> | undefined
+): void {
+  if (
+    params &&
+    typeof params === 'object' &&
+    !Array.isArray(params)
+  ) {
+    pending.paramsSnapshot = {
+      ...(pending.paramsSnapshot ?? {}),
+      ...params
+    }
+    const recMeta = extractRecaptchaFromParams(pending.paramsSnapshot)
+    if (recMeta) {
+      pending.recaptchaSiteKey = recMeta.siteKey
+      pending.recaptchaVersion = recMeta.version
+    }
+  }
+}
+
+function clearSignupBlockingFlags(
+  pending: SignupPendingStateV1
+): void {
+  pending.needsRecaptchaBeforeEmail = false
+  pending.needsRegistrationTokenBeforeEmail = false
+  pending.needsTermsAcceptanceBeforeEmail = false
+}
+
+function refreshTermsSnapshot(pending: SignupPendingStateV1): void {
+  pending.termsPoliciesSnapshot = extractTermsPoliciesFromParams(
+    pending.paramsSnapshot,
+    preferredSignupLocales()
+  )
+  writeSignupPending(pending)
+}
+
+/**
+ * After a successful interim `registerRequest`, decide next blocker or loop.
+ */
+async function resumeSignupPipeline(
+  pending: SignupPendingStateV1,
+  authClient: RegisterAuthClient,
+  uia: MatrixUiaData
+): Promise<void> {
+  clearSignupBlockingFlags(pending)
+  if (uia.session) {
+    pending.session = uia.session
+  }
+  mergeParamsIntoPending(
+    pending,
+    uia.params &&
+      typeof uia.params === 'object' &&
+      !Array.isArray(uia.params)
+      ? (uia.params as Record<string, unknown>)
+      : undefined
+  )
+  const completedList = uia.completed || []
+  pending.completedStagesSnapshot = [...completedList]
+  const nextStageRaw = getNextAuthStage(pending.flowStages, completedList)
+  if (!nextStageRaw) {
+    throw new Error(SIGNUP_REGISTRATION_UNSUPPORTED_STAGE)
+  }
+  if (isSsoStage(nextStageRaw)) {
+    throw new Error(SIGNUP_SSO_USE_WEB_CLIENT)
+  }
+  if (isMsisdnStage(nextStageRaw)) {
+    throw new Error(SIGNUP_MSISDN_NOT_SUPPORTED)
+  }
+  writeSignupPending(pending)
+
+  if (isRegistrationTokenStage(nextStageRaw)) {
+    pending.needsRegistrationTokenBeforeEmail = true
+    writeSignupPending(pending)
+    return
+  }
+  if (isTermsStage(nextStageRaw)) {
+    pending.needsTermsAcceptanceBeforeEmail = true
+    refreshTermsSnapshot(pending)
+    writeSignupPending(pending)
+    return
+  }
+  if (nextStageRaw === RECAPTCHA_STAGE) {
+    pending.needsRecaptchaBeforeEmail = true
+    writeSignupPending(pending)
+    return
+  }
+
+  const nextLink = `${window.location.origin}/signup/verify-email`
+  if (nextStageRaw === EMAIL_IDENTITY_STAGE && !pending.sid) {
+    if (typeof authClient.requestRegisterEmailToken !== 'function') {
+      throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
+    }
+    const tokenSid = await authClient.requestRegisterEmailToken(
+      pending.email,
+      pending.clientSecret,
+      1,
+      nextLink
+    ) as { sid?: string }
+    const sid = tokenSid.sid
+    if (!sid) {
+      throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
+    }
+    pending.sid = sid
+    writeSignupPending(pending)
+    return
+  }
+
+  await runSignupFinalizeLoop(pending, authClient, {
+    initialCompleted: completedList,
+    initialSession: pending.session
+  })
 }
 
 function isEmailNotVerifiedError(error: unknown): boolean {
@@ -173,6 +606,22 @@ function isEmailNotVerifiedError(error: unknown): boolean {
     return true
   }
   return false
+}
+
+function isLikelyRegistrationTokenRejected(error: unknown): boolean {
+  const code = readMatrixErrorCode(error).toUpperCase()
+  const message = readMatrixErrorMessage(error).toLowerCase()
+  return (
+    code.includes('TOKEN') ||
+    message.includes('registration token') ||
+    message.includes('invalid token') ||
+    message.includes('token is not valid')
+  )
+}
+
+function isLikelyTermsRejected(error: unknown): boolean {
+  const msg = readMatrixErrorMessage(error).toLowerCase()
+  return msg.includes('terms') || msg.includes('policy')
 }
 
 type RegisterAuthClient = MatrixClient & {
@@ -238,6 +687,28 @@ export function buildRecaptchaAuthPayload(
     type: RECAPTCHA_STAGE,
     session: sessionId,
     response: responseToken
+  }
+}
+
+export function buildRegistrationTokenAuthPayload(
+  sessionId: string,
+  opaqueToken: string,
+  matrixStageIdentifier: string
+): Record<string, unknown> {
+  return {
+    type: matrixStageIdentifier,
+    session: sessionId,
+    token: opaqueToken.trim()
+  }
+}
+
+export function buildTermsAuthPayload(
+  sessionId: string,
+  matrixStageIdentifier: string
+): Record<string, unknown> {
+  return {
+    type: matrixStageIdentifier,
+    session: sessionId
   }
 }
 
@@ -362,13 +833,23 @@ export async function startEmailRegistration(
       }
       throw error
     }
-    const flowStages = pickFlowWithEmail(uia.flows)
-    if (!flowStages) {
+    const picked = pickCompletableEmailSignupFlow(uia.flows)
+    if (!picked.ok) {
       if (isSignupUnsupported(error)) {
         throw new Error(SIGNUP_UNAVAILABLE_ERROR)
       }
+      if (picked.reason === 'sso_only') {
+        throw new Error(SIGNUP_SSO_USE_WEB_CLIENT)
+      }
+      if (picked.reason === 'msisdn_block') {
+        throw new Error(SIGNUP_MSISDN_NOT_SUPPORTED)
+      }
+      if (picked.reason === 'unsupported') {
+        throw new Error(SIGNUP_REGISTRATION_UNSUPPORTED_STAGE)
+      }
       throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
     }
+    const flowStages = picked.stages
     const paramsRaw = uia.params
     const params: Record<string, unknown> =
       paramsRaw &&
@@ -377,11 +858,12 @@ export async function startEmailRegistration(
         ? (paramsRaw as Record<string, unknown>)
         : {}
     const completedInitial = uia.completed || []
-    const firstStage = getNextAuthStage(flowStages, completedInitial)
+    const firstStageRaw = getNextAuthStage(flowStages, completedInitial)
     const recMeta = extractRecaptchaFromParams(params)
 
-    if (firstStage === RECAPTCHA_STAGE) {
-      const pendingCaptchaFirst: SignupPendingStateV1 = {
+    function buildBasePending(part: Partial<SignupPendingStateV1>):
+      SignupPendingStateV1 {
+      return {
         v: SIGNUP_PENDING_V,
         baseUrl: resolved,
         username: normUser,
@@ -389,84 +871,121 @@ export async function startEmailRegistration(
         email: trimmed,
         clientSecret,
         sid: '',
-        session: uia.session,
-        initialSession: uia.session,
+        session: uia.session ?? '',
+        initialSession: uia.session ?? '',
         flowStages,
-        paramsSnapshot: params,
+        paramsSnapshot: Object.keys(params).length > 0 ? params : undefined,
         recaptchaSiteKey: recMeta?.siteKey,
         recaptchaVersion: recMeta?.version ?? 'v2',
-        needsRecaptchaBeforeEmail: true
+        completedStagesSnapshot: [...completedInitial],
+        ...part
       }
-      writeSignupPending(pendingCaptchaFirst)
+    }
+
+    if (!firstStageRaw) {
+      throw new Error(SIGNUP_REGISTRATION_UNSUPPORTED_STAGE)
+    }
+    if (isSsoStage(firstStageRaw)) {
+      throw new Error(SIGNUP_SSO_USE_WEB_CLIENT)
+    }
+    if (isMsisdnStage(firstStageRaw)) {
+      throw new Error(SIGNUP_MSISDN_NOT_SUPPORTED)
+    }
+    if (isRegistrationTokenStage(firstStageRaw)) {
+      const pendingToken: SignupPendingStateV1 =
+        buildBasePending({ needsRegistrationTokenBeforeEmail: true })
+      writeSignupPending(pendingToken)
+      return
+    }
+    if (isTermsStage(firstStageRaw)) {
+      const pendingTerms = buildBasePending({
+        needsTermsAcceptanceBeforeEmail: true
+      })
+      writeSignupPending(pendingTerms)
+      refreshTermsSnapshot(pendingTerms)
+      writeSignupPending(pendingTerms)
+      return
+    }
+    if (firstStageRaw === RECAPTCHA_STAGE) {
+      writeSignupPending(
+        buildBasePending({
+          needsRecaptchaBeforeEmail: true
+        })
+      )
       return
     }
 
     if (typeof authClient.requestRegisterEmailToken !== 'function') {
       throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
     }
-    const token = await authClient.requestRegisterEmailToken(
+    const sidResponse = await authClient.requestRegisterEmailToken(
       trimmed,
       clientSecret,
       1,
       nextLink
     ) as { sid?: string }
-    const sid = token.sid
+    const sid = sidResponse.sid
     if (!sid) {
       throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
     }
-    const pending: SignupPendingStateV1 = {
-      v: SIGNUP_PENDING_V,
-      baseUrl: resolved,
-      username: normUser,
-      password,
-      email: trimmed,
-      clientSecret,
+    const pendingRegular: SignupPendingStateV1 = buildBasePending({
       sid,
-      session: uia.session,
-      initialSession: uia.session,
-      flowStages,
-      paramsSnapshot: Object.keys(params).length > 0 ? params : undefined,
-      recaptchaSiteKey: recMeta?.siteKey,
-      recaptchaVersion: recMeta?.version,
       needsRecaptchaBeforeEmail: false
-    }
-    writeSignupPending(pending)
+    })
+    writeSignupPending(pendingRegular)
   }
 }
 
 type FinalizeLoopOptions = {
   recaptchaResponse?: string | null
+  registrationTokenOverride?: string | null
   initialCompleted?: string[]
   initialSession?: string | null
 }
 
 async function runSignupFinalizeLoop(
-  pending: SignupPendingStateV1,
+  pendingArg: SignupPendingStateV1,
   authClient: RegisterAuthClient,
   loopOptions?: FinalizeLoopOptions
 ): Promise<void> {
+  const pendingLocal: SignupPendingStateV1 = pendingArg
+
   let session =
     loopOptions?.initialSession != null &&
       loopOptions.initialSession !== ''
       ? loopOptions.initialSession
-      : pending.session
-  let completedList = [...(loopOptions?.initialCompleted ?? [])]
+      : pendingLocal.session
+  let completedList: string[]
+  if (loopOptions?.initialCompleted != null) {
+    completedList = [...loopOptions.initialCompleted]
+  } else {
+    completedList = [...(pendingLocal.completedStagesSnapshot ?? [])]
+  }
+  pendingLocal.completedStagesSnapshot = [...completedList]
   let pendingRecaptchaToken =
     loopOptions?.recaptchaResponse?.trim() ?? ''
+  let pendingOpaqueToken =
+    loopOptions?.registrationTokenOverride?.trim() ?? ''
 
   for (let round = 0; round < 12; round++) {
     const nextStage = getNextAuthStage(
-      pending.flowStages,
+      pendingLocal.flowStages,
       completedList
     )
     if (!nextStage) {
       throw new Error('Sign up failed')
     }
+    if (isSsoStage(nextStage)) {
+      throw new Error(SIGNUP_SSO_USE_WEB_CLIENT)
+    }
+    if (isMsisdnStage(nextStage)) {
+      throw new Error(SIGNUP_MSISDN_NOT_SUPPORTED)
+    }
     let authPayload: Record<string, unknown>
     if (nextStage === EMAIL_IDENTITY_STAGE) {
       authPayload = buildEmailAuthPayload(
         authClient,
-        pending,
+        pendingLocal,
         session
       )
     } else if (nextStage === DUMMY_STAGE) {
@@ -478,13 +997,34 @@ async function runSignupFinalizeLoop(
       }
       pendingRecaptchaToken = ''
       authPayload = buildRecaptchaAuthPayload(session, tokenToSend)
+    } else if (isRegistrationTokenStage(nextStage)) {
+      const opaque = pendingOpaqueToken.trim() ||
+        (pendingLocal.registrationTokenDraft || '').trim()
+      if (!opaque) {
+        pendingLocal.needsRegistrationTokenBeforeEmail = true
+        writeSignupPending(pendingLocal)
+        throw new Error(SIGNUP_REGISTRATION_TOKEN_REQUIRED)
+      }
+      pendingOpaqueToken = ''
+      pendingLocal.registrationTokenDraft = opaque
+      writeSignupPending(pendingLocal)
+      authPayload = buildRegistrationTokenAuthPayload(
+        session,
+        opaque,
+        nextStage
+      )
+    } else if (isTermsStage(nextStage)) {
+      pendingLocal.needsTermsAcceptanceBeforeEmail = true
+      refreshTermsSnapshot(pendingLocal)
+      writeSignupPending(pendingLocal)
+      throw new Error(SIGNUP_TERMS_ACCEPTANCE_REQUIRED)
     } else {
       throw new Error(SIGNUP_REGISTRATION_UNSUPPORTED_STAGE)
     }
     try {
       await authClient.registerRequest({
-        username: pending.username,
-        password: pending.password,
+        username: pendingLocal.username,
+        password: pendingLocal.password,
         inhibit_login: true,
         auth: authPayload
       })
@@ -509,13 +1049,25 @@ async function runSignupFinalizeLoop(
       ) {
         throw new Error(SIGNUP_RECAPTCHA_FAILED)
       }
+      if (
+        isRegistrationTokenStage(nextStage) &&
+        isLikelyRegistrationTokenRejected(error)
+      ) {
+        throw new Error(SIGNUP_REGISTRATION_TOKEN_REJECTED)
+      }
+      if (
+        isTermsStage(nextStage) &&
+        isLikelyTermsRejected(error)
+      ) {
+        throw new Error(SIGNUP_TERMS_ACCEPTANCE_REQUIRED)
+      }
       const uia = readMatrixUiaData(error)
       if (uia) {
         if (
           round === 0 &&
           nextStage === EMAIL_IDENTITY_STAGE &&
           uia.session &&
-          uia.session !== pending.session &&
+          uia.session !== pendingLocal.session &&
           !(uia.completed || []).includes(EMAIL_IDENTITY_STAGE) &&
           !isEmailNotVerifiedError(error)
         ) {
@@ -525,8 +1077,17 @@ async function runSignupFinalizeLoop(
           round === 0 &&
           nextStage === RECAPTCHA_STAGE &&
           uia.session &&
-          uia.session !== pending.session &&
+          uia.session !== pendingLocal.session &&
           !(uia.completed || []).includes(RECAPTCHA_STAGE)
+        ) {
+          throw new Error(SIGNUP_SESSION_EXPIRED)
+        }
+        if (
+          round === 0 &&
+          isRegistrationTokenStage(nextStage) &&
+          uia.session &&
+          uia.session !== pendingLocal.session &&
+          !(uia.completed || []).includes(nextStage)
         ) {
           throw new Error(SIGNUP_SESSION_EXPIRED)
         }
@@ -536,27 +1097,17 @@ async function runSignupFinalizeLoop(
         if (Array.isArray(uia.completed)) {
           completedList = [...(uia.completed as string[])]
         }
-        const mergedParams =
+        mergeParamsIntoPending(
+          pendingLocal,
           uia.params &&
-          typeof uia.params === 'object' &&
-          !Array.isArray(uia.params)
+            typeof uia.params === 'object' &&
+            !Array.isArray(uia.params)
             ? (uia.params as Record<string, unknown>)
             : undefined
-        if (mergedParams) {
-          pending.paramsSnapshot = {
-            ...(pending.paramsSnapshot ?? {}),
-            ...mergedParams
-          }
-          const recMeta = extractRecaptchaFromParams(
-            pending.paramsSnapshot
-          )
-          if (recMeta) {
-            pending.recaptchaSiteKey = recMeta.siteKey
-            pending.recaptchaVersion = recMeta.version
-          }
-        }
-        pending.session = session
-        writeSignupPending(pending)
+        )
+        pendingLocal.completedStagesSnapshot = [...completedList]
+        pendingLocal.session = session
+        writeSignupPending(pendingLocal)
         continue
       }
       if (
@@ -631,63 +1182,182 @@ export async function submitSignupRecaptcha(
     if (uia.session) {
       pending.session = uia.session
     }
-    const mergedParamsSubmit =
+    mergeParamsIntoPending(
+      pending,
       uia.params &&
-      typeof uia.params === 'object' &&
-      !Array.isArray(uia.params)
+        typeof uia.params === 'object' &&
+        !Array.isArray(uia.params)
         ? (uia.params as Record<string, unknown>)
         : undefined
-    if (mergedParamsSubmit) {
-      pending.paramsSnapshot = {
-        ...(pending.paramsSnapshot ?? {}),
-        ...mergedParamsSubmit
-      }
-      const recMetaSubmit = extractRecaptchaFromParams(
-        pending.paramsSnapshot
-      )
-      if (recMetaSubmit) {
-        pending.recaptchaSiteKey = recMetaSubmit.siteKey
-        pending.recaptchaVersion = recMetaSubmit.version
-      }
-    }
-    pending.needsRecaptchaBeforeEmail = false
-    writeSignupPending(pending)
-
-    const completedList = uia.completed || []
-    const nextStage = getNextAuthStage(
-      pending.flowStages,
-      completedList
     )
-    const nextLink = `${window.location.origin}/signup/verify-email`
+    await resumeSignupPipeline(pending, authClient, uia)
+  }
+}
 
-    if (nextStage === EMAIL_IDENTITY_STAGE && !pending.sid) {
-      if (typeof authClient.requestRegisterEmailToken !== 'function') {
-        throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
-      }
-      const token = await authClient.requestRegisterEmailToken(
-        pending.email,
-        pending.clientSecret,
-        1,
-        nextLink
-      ) as { sid?: string }
-      const sid = token.sid
-      if (!sid) {
-        throw new Error(SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR)
-      }
-      pending.sid = sid
-      writeSignupPending(pending)
-      return
-    }
+export async function submitSignupRegistrationToken(
+  opaqueToken: string
+): Promise<void> {
+  if (typeof window === 'undefined') {
+    throw new Error(SIGNUP_PENDING_MISSING)
+  }
+  const trimmed = opaqueToken.trim()
+  if (!trimmed) {
+    throw new Error(SIGNUP_REGISTRATION_TOKEN_REQUIRED)
+  }
+  const pendingSnapshot = readSignupPending()
+  if (!pendingSnapshot) {
+    throw new Error(SIGNUP_PENDING_MISSING)
+  }
+  const snapshotTok = pendingSnapshot.completedStagesSnapshot ?? []
+  const litTok = getNextAuthStage(pendingSnapshot.flowStages, snapshotTok)
+  const awaitingTokenUx =
+    pendingSnapshot.needsRegistrationTokenBeforeEmail === true ||
+    isRegistrationTokenStage(litTok ?? '')
+  if (!awaitingTokenUx) {
+    throw new Error(SIGNUP_REGISTRATION_TOKEN_REJECTED)
+  }
+  pendingSnapshot.registrationTokenDraft = trimmed
+  writeSignupPending(pendingSnapshot)
+  const authClient = sdk.createClient({
+    baseUrl: resolveHomeserverBaseUrlForClient(pendingSnapshot.baseUrl)
+  }) as RegisterAuthClient
+  if (typeof authClient.registerRequest !== 'function') {
+    throw new Error(SIGNUP_UNAVAILABLE_ERROR)
+  }
 
-    await runSignupFinalizeLoop(pending, authClient, {
-      initialCompleted: completedList,
-      initialSession: pending.session
+  const nextStageLit = litTok
+  const registrationStageId =
+    typeof nextStageLit === 'string' &&
+      isRegistrationTokenStage(nextStageLit)
+      ? nextStageLit
+      : REGISTRATION_TOKEN_STAGE
+
+  try {
+    await authClient.registerRequest({
+      username: pendingSnapshot.username,
+      password: pendingSnapshot.password,
+      inhibit_login: true,
+      auth: buildRegistrationTokenAuthPayload(
+        pendingSnapshot.session,
+        trimmed,
+        registrationStageId
+      )
     })
+    clearSignupPending()
+    return
+  } catch (error) {
+    if (isLikelyBrowserNetworkOrCorsError(error)) {
+      throw new Error(HOMESERVER_CONNECTION_HINT_ERROR)
+    }
+    if (isLikelyRegistrationTokenRejected(error)) {
+      throw new Error(SIGNUP_REGISTRATION_TOKEN_REJECTED)
+    }
+    const uia = readMatrixUiaData(error)
+    if (!uia) {
+      if (isSignupUnsupported(error)) {
+        throw new Error(SIGNUP_UNAVAILABLE_ERROR)
+      }
+      const matrixMessage = readMatrixErrorMessage(error)
+      if (matrixMessage) {
+        throw new Error(matrixMessage)
+      }
+      throw error
+    }
+    if (uia.session) {
+      pendingSnapshot.session = uia.session
+    }
+    mergeParamsIntoPending(
+      pendingSnapshot,
+      uia.params &&
+        typeof uia.params === 'object' &&
+        !Array.isArray(uia.params)
+        ? (uia.params as Record<string, unknown>)
+        : undefined
+    )
+    await resumeSignupPipeline(pendingSnapshot, authClient, uia)
+  }
+}
+
+export async function submitSignupTermsAcceptance(): Promise<void> {
+  if (typeof window === 'undefined') {
+    throw new Error(SIGNUP_PENDING_MISSING)
+  }
+  const pending = readSignupPending()
+  if (!pending) {
+    throw new Error(SIGNUP_PENDING_MISSING)
+  }
+  const snapshotTerms = pending.completedStagesSnapshot ?? []
+  const litTerms = getNextAuthStage(pending.flowStages, snapshotTerms)
+  const awaitingTermsUx =
+    pending.needsTermsAcceptanceBeforeEmail === true ||
+    isTermsStage(litTerms ?? '')
+  if (!awaitingTermsUx) {
+    throw new Error(SIGNUP_TERMS_ACCEPTANCE_REQUIRED)
+  }
+  const authClient = sdk.createClient({
+    baseUrl: resolveHomeserverBaseUrlForClient(pending.baseUrl)
+  }) as RegisterAuthClient
+  if (typeof authClient.registerRequest !== 'function') {
+    throw new Error(SIGNUP_UNAVAILABLE_ERROR)
+  }
+
+  const nextLit = getNextAuthStage(
+    pending.flowStages,
+    snapshotTerms
+  )
+  const stageType =
+    typeof nextLit === 'string' &&
+      isTermsStage(nextLit)
+      ? nextLit
+      : TERMS_STAGE
+
+  try {
+    await authClient.registerRequest({
+      username: pending.username,
+      password: pending.password,
+      inhibit_login: true,
+      auth: buildTermsAuthPayload(pending.session, stageType)
+    })
+    clearSignupPending()
+    return
+  } catch (error) {
+    if (isLikelyBrowserNetworkOrCorsError(error)) {
+      throw new Error(HOMESERVER_CONNECTION_HINT_ERROR)
+    }
+    if (isLikelyTermsRejected(error)) {
+      throw new Error(SIGNUP_TERMS_ACCEPTANCE_REQUIRED)
+    }
+    const uia = readMatrixUiaData(error)
+    if (!uia) {
+      if (isSignupUnsupported(error)) {
+        throw new Error(SIGNUP_UNAVAILABLE_ERROR)
+      }
+      const matrixMessage = readMatrixErrorMessage(error)
+      if (matrixMessage) {
+        throw new Error(matrixMessage)
+      }
+      throw error
+    }
+    if (uia.session) {
+      pending.session = uia.session
+    }
+    mergeParamsIntoPending(
+      pending,
+      uia.params &&
+        typeof uia.params === 'object' &&
+        !Array.isArray(uia.params)
+        ? (uia.params as Record<string, unknown>)
+        : undefined
+    )
+    await resumeSignupPipeline(pending, authClient, uia)
   }
 }
 
 export async function finalizeEmailRegistration(
-  options?: { recaptchaResponse?: string | null }
+  options?: {
+    recaptchaResponse?: string | null
+    registrationToken?: string | null
+  }
 ): Promise<void> {
   if (typeof window === 'undefined') {
     throw new Error(SIGNUP_PENDING_MISSING)
@@ -702,8 +1372,10 @@ export async function finalizeEmailRegistration(
   if (typeof authClient.registerRequest !== 'function') {
     throw new Error(SIGNUP_UNAVAILABLE_ERROR)
   }
+
   await runSignupFinalizeLoop(pending, authClient, {
-    recaptchaResponse: options?.recaptchaResponse
+    recaptchaResponse: options?.recaptchaResponse,
+    registrationTokenOverride: options?.registrationToken
   })
 }
 

--- a/app/composables/useAppI18n.ts
+++ b/app/composables/useAppI18n.ts
@@ -35,6 +35,28 @@ const messages: Record<AppLocale, Record<string, string>> = {
     'auth.signUpUnsupportedAuthStage':
       'This homeserver needs an additional sign-up step that Decentra ' +
       'does not support yet.',
+    'auth.signUpSsoUseWebClient':
+      'This homeserver only allows SSO sign-up. Please use the official ' +
+      'Element web client in a browser, then continue in Decentra after ' +
+      'your account exists.',
+    'auth.signUpMsisdnUnsupported':
+      'This homeserver expects phone-number (SMS) confirmation. Decentra ' +
+      'does not support SMS sign-up yet.',
+    'auth.signUpRegistrationTokenTitle': 'Registration token',
+    'auth.signUpRegistrationTokenPlaceholder':
+      'Paste token from homeserver admins',
+    'auth.signUpRegistrationTokenSubmit': 'Continue',
+    'auth.signUpRegistrationTokenRequired':
+      'Homeserver requires a registration token. Enter it below.',
+    'auth.signUpRegistrationTokenRejected':
+      'This registration token was rejected. Check with your homeserver ' +
+      'and try another token.',
+    'auth.signUpTermsTitle': 'Accept policies',
+    'auth.signUpTermsAcceptCheckbox':
+      'I have read and agree to all policies linked above.',
+    'auth.signUpTermsContinue': 'Continue',
+    'auth.signUpTermsEmptyPolicies':
+      'This homeserver did not send usable policy URLs. Cannot continue.',
     'auth.signUpRetry': 'Try again',
     'auth.signUpBackToForm': 'Back to sign-up',
     'auth.signUpCaptchaTitle': 'Verify you are human',
@@ -230,6 +252,31 @@ const messages: Record<AppLocale, Record<string, string>> = {
     'auth.signUpUnsupportedAuthStage':
       'Dieser Homeserver verlangt einen weiteren Registrierungs-Schritt, ' +
       'den Decentra noch nicht unterstuetzt.',
+    'auth.signUpSsoUseWebClient':
+      'Dieser Homeserver erlaubt die Registrierung nur ueber SSO. Bitte ' +
+      'die offizielle Element-Web-App im Browser nutzen, danach kannst du ' +
+      'hier fortfahren, sobald ein Account besteht.',
+    'auth.signUpMsisdnUnsupported':
+      'Dieser Homeserver erwartet Bestaetigung per Mobilnummer/SMS. ' +
+      'Decentra unterstuetzt diese SMS-Registrierung noch nicht.',
+    'auth.signUpRegistrationTokenTitle':
+      'Registrierungs-Token',
+    'auth.signUpRegistrationTokenPlaceholder':
+      'Token von den Homeserver-Admins einfuegen',
+    'auth.signUpRegistrationTokenSubmit': 'Fortfahren',
+    'auth.signUpRegistrationTokenRequired':
+      'Der Homeserver braucht ein Registrierungs-Token.' +
+      ' Bitte gib es unten ein.',
+    'auth.signUpRegistrationTokenRejected':
+      'Das Token wird vom Homeserver nicht akzeptiert. Bitte pruefen ' +
+      'oder ein gueltiges Token verwenden.',
+    'auth.signUpTermsTitle': 'Richtlinien akzeptieren',
+    'auth.signUpTermsAcceptCheckbox':
+      'Ich habe die verlinkten Richtlinien gelesen und stimme allen zu.',
+    'auth.signUpTermsContinue': 'Fortfahren',
+    'auth.signUpTermsEmptyPolicies':
+      'Nutzbare Links zu Richtlinien fehlen. Fortsetzen ist nicht ' +
+      'moeglich.',
     'auth.signUpRetry': 'Erneut versuchen',
     'auth.signUpBackToForm': 'Zurueck zur Registrierung',
     'auth.signUpCaptchaTitle': 'Bestaetigung gegen Bots',

--- a/app/composables/useMatrixClient.ts
+++ b/app/composables/useMatrixClient.ts
@@ -26,8 +26,13 @@ import {
   readSignupPendingPublic,
   registerWithDummy,
   signupPendingNeedsRecaptchaBeforeEmail,
+  signupPendingNeedsRegistrationTokenBeforeEmail,
+  signupPendingNeedsTermsBeforeEmail,
+  hydrateTermsPoliciesForPending,
   startEmailRegistration,
   submitSignupRecaptcha,
+  submitSignupRegistrationToken,
+  submitSignupTermsAcceptance,
   SIGNUP_EMAIL_NOT_CONFIRMED_YET,
   SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR,
   SIGNUP_PENDING_MISSING,
@@ -35,17 +40,27 @@ import {
   SIGNUP_RECAPTCHA_FAILED,
   SIGNUP_RECAPTCHA_TOKEN_REQUIRED,
   SIGNUP_REGISTRATION_UNSUPPORTED_STAGE,
+  SIGNUP_REGISTRATION_TOKEN_REJECTED,
+  SIGNUP_REGISTRATION_TOKEN_REQUIRED,
+  SIGNUP_TERMS_ACCEPTANCE_REQUIRED,
+  SIGNUP_MSISDN_NOT_SUPPORTED,
+  SIGNUP_SSO_USE_WEB_CLIENT,
   SIGNUP_SESSION_EXPIRED,
   SIGNUP_UNAVAILABLE_ERROR
 } from './matrix/matrixRegistrationUia'
 export {
   clearSignupPending,
   finalizeEmailRegistration,
+  hydrateTermsPoliciesForPending,
   readSignupPendingPublic,
   registerWithDummy,
   signupPendingNeedsRecaptchaBeforeEmail,
+  signupPendingNeedsRegistrationTokenBeforeEmail,
+  signupPendingNeedsTermsBeforeEmail,
   startEmailRegistration,
   submitSignupRecaptcha,
+  submitSignupRegistrationToken,
+  submitSignupTermsAcceptance,
   SIGNUP_EMAIL_NOT_CONFIRMED_YET,
   SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR,
   SIGNUP_PENDING_MISSING,
@@ -53,14 +68,28 @@ export {
   SIGNUP_RECAPTCHA_FAILED,
   SIGNUP_RECAPTCHA_TOKEN_REQUIRED,
   SIGNUP_REGISTRATION_UNSUPPORTED_STAGE,
+  SIGNUP_REGISTRATION_TOKEN_REJECTED,
+  SIGNUP_REGISTRATION_TOKEN_REQUIRED,
+  SIGNUP_TERMS_ACCEPTANCE_REQUIRED,
+  SIGNUP_MSISDN_NOT_SUPPORTED,
+  SIGNUP_SSO_USE_WEB_CLIENT,
   SIGNUP_SESSION_EXPIRED,
   SIGNUP_UNAVAILABLE_ERROR
 }
 export type { SignupPendingStateV1 } from './matrix/matrixRegistrationUia'
+export type { SignupTermsPolicyItem } from './matrix/matrixRegistrationUia'
 export {
   buildRecaptchaAuthPayload,
+  buildRegistrationTokenAuthPayload,
+  buildTermsAuthPayload,
   extractRecaptchaFromParams,
-  RECAPTCHA_STAGE
+  extractTermsPoliciesFromParams,
+  pickCompletableEmailSignupFlow,
+  RECAPTCHA_STAGE,
+  REGISTRATION_TOKEN_STAGE,
+  TERMS_STAGE,
+  isRegistrationTokenStage,
+  isTermsStage
 } from './matrix/matrixRegistrationUia'
 
 interface StoredMatrixSession {

--- a/app/pages/signup.vue
+++ b/app/pages/signup.vue
@@ -1,34 +1,53 @@
 <script setup lang="ts">
+import type { SignupTermsPolicyItem } from '~/composables/matrix/matrixRegistrationUia'
 import { ref } from 'vue'
 import {
   clearSignupPending,
   extractRecaptchaFromParams,
   HOMESERVER_CONNECTION_HINT_ERROR,
+  hydrateTermsPoliciesForPending,
   readSignupPendingPublic,
   SIGNUP_EMAIL_NOT_CONFIRMED_YET,
   SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR,
+  SIGNUP_MSISDN_NOT_SUPPORTED,
   SIGNUP_PENDING_MISSING,
   SIGNUP_PENDING_STORAGE_KEY,
   SIGNUP_RECAPTCHA_FAILED,
+  SIGNUP_RECAPTCHA_TOKEN_REQUIRED,
   SIGNUP_REGISTRATION_UNSUPPORTED_STAGE,
+  SIGNUP_REGISTRATION_TOKEN_REJECTED,
+  SIGNUP_REGISTRATION_TOKEN_REQUIRED,
   SIGNUP_SESSION_EXPIRED,
+  SIGNUP_SSO_USE_WEB_CLIENT,
+  SIGNUP_TERMS_ACCEPTANCE_REQUIRED,
   SIGNUP_UNAVAILABLE_ERROR,
   startEmailRegistration,
   submitSignupRecaptcha,
+  submitSignupRegistrationToken,
+  submitSignupTermsAcceptance,
   useMatrixClient
 } from '~/composables/useMatrixClient'
 import { useAppI18n } from '~/composables/useAppI18n'
+
+type SignupStep =
+  | 'form'
+  | 'registrationToken'
+  | 'terms'
+  | 'emailSent'
+  | 'captcha'
 
 const baseUrl = ref('https://matrix.org')
 const email = ref('')
 const username = ref('')
 const password = ref('')
+const registrationTokenInput = ref('')
 const error = ref('')
 const loading = ref(false)
-const step = ref<'form' | 'emailSent' | 'captcha'>('form')
+const step = ref<SignupStep>('form')
 
 const captchaSiteKey = ref('')
 const captchaVersion = ref<'v2' | 'v3'>('v2')
+const termsPolicies = ref<SignupTermsPolicyItem[]>([])
 
 const { isLoggedIn } = useMatrixClient()
 const { translateText } = useAppI18n()
@@ -41,30 +60,48 @@ function mapSignupError(thrown: unknown): string {
   if (!(thrown instanceof Error) || !thrown.message) {
     return translateText('auth.signUpFailed')
   }
-  const m = thrown.message
-  if (m === SIGNUP_UNAVAILABLE_ERROR) {
+  const message = thrown.message
+  if (message === SIGNUP_UNAVAILABLE_ERROR) {
     return translateText('auth.signUpUnavailable')
   }
-  if (m === SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR) {
+  if (message === SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR) {
     return translateText('auth.signUpEmailVerificationRequired')
   }
-  if (m === HOMESERVER_CONNECTION_HINT_ERROR) {
+  if (message === HOMESERVER_CONNECTION_HINT_ERROR) {
     return translateText('auth.homeserverConnectionHint')
   }
-  if (m === SIGNUP_EMAIL_NOT_CONFIRMED_YET) {
+  if (message === SIGNUP_EMAIL_NOT_CONFIRMED_YET) {
     return translateText('auth.signUpEmailNotConfirmedYet')
   }
-  if (m === SIGNUP_PENDING_MISSING) {
+  if (message === SIGNUP_PENDING_MISSING) {
     return translateText('auth.signUpPendingMissing')
   }
-  if (m === SIGNUP_SESSION_EXPIRED) {
+  if (message === SIGNUP_SESSION_EXPIRED) {
     return translateText('auth.signUpSessionExpired')
   }
-  if (m === SIGNUP_REGISTRATION_UNSUPPORTED_STAGE) {
+  if (message === SIGNUP_REGISTRATION_UNSUPPORTED_STAGE) {
     return translateText('auth.signUpUnsupportedAuthStage')
   }
-  if (m === SIGNUP_RECAPTCHA_FAILED) {
+  if (message === SIGNUP_SSO_USE_WEB_CLIENT) {
+    return translateText('auth.signUpSsoUseWebClient')
+  }
+  if (message === SIGNUP_MSISDN_NOT_SUPPORTED) {
+    return translateText('auth.signUpMsisdnUnsupported')
+  }
+  if (message === SIGNUP_RECAPTCHA_FAILED) {
     return translateText('auth.signUpRecaptchaFailed')
+  }
+  if (message === SIGNUP_RECAPTCHA_TOKEN_REQUIRED) {
+    return translateText('auth.signUpRecaptchaRequired')
+  }
+  if (message === SIGNUP_REGISTRATION_TOKEN_REQUIRED) {
+    return translateText('auth.signUpRegistrationTokenRequired')
+  }
+  if (message === SIGNUP_REGISTRATION_TOKEN_REJECTED) {
+    return translateText('auth.signUpRegistrationTokenRejected')
+  }
+  if (message === SIGNUP_TERMS_ACCEPTANCE_REQUIRED) {
+    return translateText('auth.signUpTermsTitle')
   }
   return translateText('auth.signUpFailed')
 }
@@ -94,6 +131,43 @@ function hydrateCaptchaFromPending(): void {
     'v2'
 }
 
+/**
+ * Advances UI after server stored sign-up intermediate state (sessionStorage).
+ */
+function applySignupStepFromPending(): void {
+  const pending = readSignupPendingPublic()
+  error.value = ''
+  if (!pending) {
+    step.value = 'emailSent'
+    return
+  }
+  if (pending.needsRegistrationTokenBeforeEmail) {
+    step.value = 'registrationToken'
+    return
+  }
+  if (pending.needsTermsAcceptanceBeforeEmail) {
+    termsPolicies.value = hydrateTermsPoliciesForPending()
+    step.value = 'terms'
+    return
+  }
+  if (pending.needsRecaptchaBeforeEmail) {
+    hydrateCaptchaFromPending()
+    if (!captchaSiteKey.value.trim()) {
+      error.value =
+        translateText('auth.signUpRecaptchaMissingSiteKey')
+      step.value = 'form'
+      return
+    }
+    step.value = 'captcha'
+    return
+  }
+  if (pending.sid) {
+    step.value = 'emailSent'
+    return
+  }
+  step.value = 'emailSent'
+}
+
 async function handleSignup() {
   error.value = ''
   loading.value = true
@@ -105,34 +179,15 @@ async function handleSignup() {
       password.value,
       email.value
     )
-    const isBrowserClient = typeof window !== 'undefined' &&
+    const isBrowserClient =
+      typeof window !== 'undefined' &&
       (import.meta as { client?: boolean }).client !== false
-    if (isBrowserClient) {
-      const rawPending = sessionStorage.getItem(SIGNUP_PENDING_STORAGE_KEY)
-      if (rawPending) {
-        try {
-          const parsed = JSON.parse(rawPending) as {
-            needsRecaptchaBeforeEmail?: boolean
-          }
-          if (parsed.needsRecaptchaBeforeEmail === true) {
-            hydrateCaptchaFromPending()
-            if (!captchaSiteKey.value.trim()) {
-              error.value = translateText(
-                'auth.signUpRecaptchaMissingSiteKey'
-              )
-              step.value = 'form'
-              return
-            }
-            step.value = 'captcha'
-            return
-          }
-        } catch {
-          step.value = 'emailSent'
-          return
-        }
-        step.value = 'emailSent'
-        return
-      }
+    const hasStoredPending =
+      isBrowserClient &&
+      Boolean(sessionStorage.getItem(SIGNUP_PENDING_STORAGE_KEY))
+    if (hasStoredPending) {
+      applySignupStepFromPending()
+      return
     }
     await navigateTo({
       path: '/login',
@@ -145,24 +200,64 @@ async function handleSignup() {
   }
 }
 
-async function handleCaptchaVerified(token: string) {
+async function handleRegistrationTokenContinue() {
   error.value = ''
   loading.value = true
   try {
-    await submitSignupRecaptcha(token)
-    const pendingAfter = readSignupPendingPublic()
-    if (!pendingAfter) {
+    await submitSignupRegistrationToken(registrationTokenInput.value)
+    registrationTokenInput.value = ''
+    if (!readSignupPendingPublic()) {
       await navigateTo({
         path: '/login',
         query: { signup: 'success' }
       })
       return
     }
-    if (pendingAfter.sid) {
-      step.value = 'emailSent'
+    applySignupStepFromPending()
+  } catch (thrownError) {
+    error.value = mapSignupError(thrownError)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleTermsContinue() {
+  error.value = ''
+  loading.value = true
+  try {
+    await submitSignupTermsAcceptance()
+    if (!readSignupPendingPublic()) {
+      await navigateTo({
+        path: '/login',
+        query: { signup: 'success' }
+      })
       return
     }
-    error.value = translateText('auth.signUpFailed')
+    applySignupStepFromPending()
+  } catch (thrownError) {
+    error.value = mapSignupError(thrownError)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleCaptchaVerified(token: string) {
+  error.value = ''
+  loading.value = true
+  try {
+    await submitSignupRecaptcha(token)
+    if (!readSignupPendingPublic()) {
+      await navigateTo({
+        path: '/login',
+        query: { signup: 'success' }
+      })
+      return
+    }
+    applySignupStepFromPending()
+    const lingering = readSignupPendingPublic()
+    if (lingering && !lingering.sid) {
+      error.value = translateText('auth.signUpFailed')
+    }
   } catch (thrownError) {
     error.value = mapSignupError(thrownError)
   } finally {
@@ -175,17 +270,16 @@ function resetToForm() {
   step.value = 'form'
   error.value = ''
   captchaSiteKey.value = ''
+  termsPolicies.value = []
+  registrationTokenInput.value = ''
 }
 
 function clearForm() {
+  resetToForm()
   baseUrl.value = 'https://matrix.org'
   email.value = ''
   username.value = ''
   password.value = ''
-  error.value = ''
-  clearSignupPending()
-  step.value = 'form'
-  captchaSiteKey.value = ''
 }
 </script>
 
@@ -273,6 +367,10 @@ function clearForm() {
             />
           </UFormField>
 
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            {{ translateText('auth.signUpHomeserverPrivacyNotice') }}
+          </p>
+
           <UAlert
             v-if="error"
             color="error"
@@ -300,6 +398,90 @@ function clearForm() {
             </UButton>
           </div>
         </form>
+      </UCard>
+
+      <UCard
+        v-else-if="step === 'registrationToken'"
+        class="w-full max-w-md"
+      >
+        <template #header>
+          <h1 class="text-xl font-semibold">
+            {{ translateText('auth.signUpRegistrationTokenTitle') }}
+          </h1>
+        </template>
+        <div class="space-y-4">
+          <p class="text-sm text-gray-300">
+            {{ translateText('auth.signUpRegistrationTokenRequired') }}
+          </p>
+          <UAlert
+            v-if="error"
+            color="error"
+            :title="error"
+            class="mb-2"
+          />
+          <UFormField
+            :label="translateText(
+              'auth.signUpRegistrationTokenPlaceholder'
+            )"
+          >
+            <UInput
+              v-model="registrationTokenInput"
+              type="password"
+              autocomplete="off"
+            />
+          </UFormField>
+          <UButton
+            class="w-full justify-center"
+            :loading="loading"
+            :disabled="!registrationTokenInput.trim()"
+            @click="handleRegistrationTokenContinue"
+          >
+            {{ translateText('auth.signUpRegistrationTokenSubmit') }}
+          </UButton>
+          <UButton
+            type="button"
+            color="neutral"
+            variant="outline"
+            class="w-full justify-center"
+            :disabled="loading"
+            @click="resetToForm"
+          >
+            {{ translateText('auth.signUpCancel') }}
+          </UButton>
+        </div>
+      </UCard>
+
+      <UCard
+        v-else-if="step === 'terms'"
+        class="w-full max-w-md"
+      >
+        <template #header>
+          <h1 class="text-xl font-semibold">
+            {{ translateText('auth.signUpTermsTitle') }}
+          </h1>
+        </template>
+        <div class="space-y-4">
+          <UAlert
+            v-if="error"
+            color="error"
+            :title="error"
+            class="mb-2"
+          />
+          <SignupTermsStep
+            :policies="termsPolicies"
+            @continue="handleTermsContinue"
+          />
+          <UButton
+            type="button"
+            color="neutral"
+            variant="outline"
+            class="w-full justify-center"
+            :disabled="loading"
+            @click="resetToForm"
+          >
+            {{ translateText('auth.signUpCancel') }}
+          </UButton>
+        </div>
       </UCard>
 
       <UCard

--- a/app/pages/signup/verify-email.vue
+++ b/app/pages/signup/verify-email.vue
@@ -1,18 +1,27 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import type { SignupTermsPolicyItem } from '~/composables/matrix/matrixRegistrationUia'
+import { computed, onMounted, ref } from 'vue'
 import {
   extractRecaptchaFromParams,
   finalizeEmailRegistration,
   HOMESERVER_CONNECTION_HINT_ERROR,
+  hydrateTermsPoliciesForPending,
   readSignupPendingPublic,
   SIGNUP_EMAIL_NOT_CONFIRMED_YET,
   SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR,
+  SIGNUP_MSISDN_NOT_SUPPORTED,
   SIGNUP_PENDING_MISSING,
   SIGNUP_RECAPTCHA_FAILED,
   SIGNUP_RECAPTCHA_TOKEN_REQUIRED,
   SIGNUP_REGISTRATION_UNSUPPORTED_STAGE,
+  SIGNUP_REGISTRATION_TOKEN_REJECTED,
+  SIGNUP_REGISTRATION_TOKEN_REQUIRED,
   SIGNUP_SESSION_EXPIRED,
+  SIGNUP_SSO_USE_WEB_CLIENT,
+  SIGNUP_TERMS_ACCEPTANCE_REQUIRED,
   SIGNUP_UNAVAILABLE_ERROR,
+  submitSignupRegistrationToken,
+  submitSignupTermsAcceptance,
   useMatrixClient
 } from '~/composables/useMatrixClient'
 import { useAppI18n } from '~/composables/useAppI18n'
@@ -22,9 +31,26 @@ const error = ref('')
 const needsCaptcha = ref(false)
 const captchaSiteKey = ref('')
 const captchaVersion = ref<'v2' | 'v3'>('v2')
+const needsToken = ref(false)
+const registrationTokenField = ref('')
+const needsTerms = ref(false)
+const termsPolicies = ref<SignupTermsPolicyItem[]>([])
 
 const { isLoggedIn } = useMatrixClient()
 const { translateText } = useAppI18n()
+
+const activeStepLabel = computed(() => {
+  if (needsTerms.value) {
+    return translateText('auth.signUpTermsTitle')
+  }
+  if (needsToken.value) {
+    return translateText('auth.signUpRegistrationTokenTitle')
+  }
+  if (needsCaptcha.value) {
+    return translateText('auth.signUpCaptchaTitle')
+  }
+  return translateText('auth.signUpEmailVerifyingTitle')
+})
 
 if (isLoggedIn.value) {
   navigateTo('/chat')
@@ -51,33 +77,48 @@ function mapError(thrown: unknown): string {
   if (!(thrown instanceof Error) || !thrown.message) {
     return translateText('auth.signUpFailed')
   }
-  const m = thrown.message
-  if (m === SIGNUP_EMAIL_NOT_CONFIRMED_YET) {
+  const messageCode = thrown.message
+  if (messageCode === SIGNUP_EMAIL_NOT_CONFIRMED_YET) {
     return translateText('auth.signUpEmailNotConfirmedYet')
   }
-  if (m === SIGNUP_PENDING_MISSING) {
+  if (messageCode === SIGNUP_PENDING_MISSING) {
     return translateText('auth.signUpPendingMissing')
   }
-  if (m === SIGNUP_SESSION_EXPIRED) {
+  if (messageCode === SIGNUP_SESSION_EXPIRED) {
     return translateText('auth.signUpSessionExpired')
   }
-  if (m === SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR) {
+  if (messageCode === SIGNUP_EMAIL_VERIFICATION_REQUIRED_ERROR) {
     return translateText('auth.signUpEmailVerificationRequired')
   }
-  if (m === SIGNUP_UNAVAILABLE_ERROR) {
+  if (messageCode === SIGNUP_UNAVAILABLE_ERROR) {
     return translateText('auth.signUpUnavailable')
   }
-  if (m === HOMESERVER_CONNECTION_HINT_ERROR) {
+  if (messageCode === HOMESERVER_CONNECTION_HINT_ERROR) {
     return translateText('auth.homeserverConnectionHint')
   }
-  if (m === SIGNUP_REGISTRATION_UNSUPPORTED_STAGE) {
+  if (messageCode === SIGNUP_REGISTRATION_UNSUPPORTED_STAGE) {
     return translateText('auth.signUpUnsupportedAuthStage')
   }
-  if (m === SIGNUP_RECAPTCHA_FAILED) {
+  if (messageCode === SIGNUP_SSO_USE_WEB_CLIENT) {
+    return translateText('auth.signUpSsoUseWebClient')
+  }
+  if (messageCode === SIGNUP_MSISDN_NOT_SUPPORTED) {
+    return translateText('auth.signUpMsisdnUnsupported')
+  }
+  if (messageCode === SIGNUP_RECAPTCHA_FAILED) {
     return translateText('auth.signUpRecaptchaFailed')
   }
-  if (m === SIGNUP_RECAPTCHA_TOKEN_REQUIRED) {
+  if (messageCode === SIGNUP_RECAPTCHA_TOKEN_REQUIRED) {
     return translateText('auth.signUpRecaptchaRequired')
+  }
+  if (messageCode === SIGNUP_REGISTRATION_TOKEN_REQUIRED) {
+    return translateText('auth.signUpRegistrationTokenRequired')
+  }
+  if (messageCode === SIGNUP_REGISTRATION_TOKEN_REJECTED) {
+    return translateText('auth.signUpRegistrationTokenRejected')
+  }
+  if (messageCode === SIGNUP_TERMS_ACCEPTANCE_REQUIRED) {
+    return translateText('auth.signUpTermsTitle')
   }
   return translateText('auth.signUpFailed')
 }
@@ -87,8 +128,12 @@ async function runFinalize(recaptchaToken?: string | null) {
   loading.value = true
   try {
     await finalizeEmailRegistration({
-      recaptchaResponse: recaptchaToken ?? undefined
+      recaptchaResponse: recaptchaToken ?? undefined,
+      registrationToken: registrationTokenField.value.trim()
+        ? registrationTokenField.value.trim()
+        : null
     })
+    registrationTokenField.value = ''
     await navigateTo({
       path: '/login',
       query: { signup: 'success' }
@@ -99,10 +144,31 @@ async function runFinalize(recaptchaToken?: string | null) {
       thrownError.message === SIGNUP_RECAPTCHA_TOKEN_REQUIRED
     ) {
       needsCaptcha.value = true
+      needsToken.value = false
+      needsTerms.value = false
       hydrateCaptchaFromPending()
       if (!captchaSiteKey.value.trim()) {
         error.value = translateText('auth.signUpRecaptchaMissingSiteKey')
       }
+      return
+    }
+    if (
+      thrownError instanceof Error &&
+      thrownError.message === SIGNUP_REGISTRATION_TOKEN_REQUIRED
+    ) {
+      needsToken.value = true
+      needsCaptcha.value = false
+      needsTerms.value = false
+      return
+    }
+    if (
+      thrownError instanceof Error &&
+      thrownError.message === SIGNUP_TERMS_ACCEPTANCE_REQUIRED
+    ) {
+      needsTerms.value = true
+      needsCaptcha.value = false
+      needsToken.value = false
+      termsPolicies.value = hydrateTermsPoliciesForPending()
       return
     }
     error.value = mapError(thrownError)
@@ -112,8 +178,39 @@ async function runFinalize(recaptchaToken?: string | null) {
 }
 
 async function handleCaptchaVerified(token: string) {
+  needsCaptcha.value = false
   await runFinalize(token)
 }
+
+async function handleTokenSubmit() {
+  error.value = ''
+  try {
+    await submitSignupRegistrationToken(registrationTokenField.value)
+    needsToken.value = false
+    registrationTokenField.value = ''
+    await runFinalize()
+  } catch (thrownError) {
+    error.value = mapError(thrownError)
+  }
+}
+
+async function handleTermsContinue() {
+  error.value = ''
+  try {
+    await submitSignupTermsAcceptance()
+    needsTerms.value = false
+    await runFinalize()
+  } catch (thrownError) {
+    error.value = mapError(thrownError)
+  }
+}
+
+const showBusyOverlay = computed(() => (
+  loading.value &&
+  !needsCaptcha.value &&
+  !needsToken.value &&
+  !needsTerms.value
+))
 
 onMounted(() => {
   void runFinalize()
@@ -125,7 +222,9 @@ onMounted(() => {
     <header
       class="border-b border-gray-200/70 bg-white/90 backdrop-blur dark:border-gray-800 dark:bg-gray-900/85"
     >
-      <div class="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-6">
+      <div
+        class="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-6"
+      >
         <NuxtLink
           to="/"
           class="text-lg font-semibold text-white/70 transition hover:text-white dark:text-white/80"
@@ -148,16 +247,12 @@ onMounted(() => {
       <UCard class="w-full max-w-md">
         <template #header>
           <h1 class="text-xl font-semibold">
-            {{
-              needsCaptcha
-                ? translateText('auth.signUpCaptchaTitle')
-                : translateText('auth.signUpEmailVerifyingTitle')
-            }}
+            {{ activeStepLabel }}
           </h1>
         </template>
         <div class="space-y-4">
           <div
-            v-if="loading && !needsCaptcha"
+            v-if="showBusyOverlay"
             class="text-sm text-gray-500 dark:text-gray-300"
           >
             {{ translateText('auth.signUpEmailVerifyingTitle') }}
@@ -168,6 +263,42 @@ onMounted(() => {
             :title="error"
             class="mb-2"
           />
+          <SignupTermsStep
+            v-if="needsTerms && termsPolicies.length > 0"
+            :policies="termsPolicies"
+            @continue="handleTermsContinue"
+          />
+          <div
+            v-if="needsToken"
+            class="space-y-3"
+          >
+            <p class="text-sm text-gray-300">
+              {{
+                translateText('auth.signUpRegistrationTokenRequired')
+              }}
+            </p>
+            <UFormField
+              :label="translateText(
+                'auth.signUpRegistrationTokenPlaceholder'
+              )"
+            >
+              <UInput
+                v-model="registrationTokenField"
+                type="password"
+                autocomplete="off"
+              />
+            </UFormField>
+            <UButton
+              class="w-full justify-center"
+              :loading="loading"
+              :disabled="!registrationTokenField.trim()"
+              @click="handleTokenSubmit"
+            >
+              {{
+                translateText('auth.signUpRegistrationTokenSubmit')
+              }}
+            </UButton>
+          </div>
           <SignupRecaptchaStep
             v-if="needsCaptcha && captchaSiteKey.trim()"
             :site-key="captchaSiteKey"
@@ -175,17 +306,13 @@ onMounted(() => {
             @verified="handleCaptchaVerified"
           />
           <div
-            v-if="!loading && !needsCaptcha"
+            v-if="
+              needsCaptcha &&
+                !captchaSiteKey.trim() &&
+                !loading
+            "
             class="flex flex-col gap-2"
           >
-            <UButton
-              v-if="error"
-              class="w-full justify-center"
-              :loading="loading"
-              @click="runFinalize()"
-            >
-              {{ translateText('auth.signUpRetry') }}
-            </UButton>
             <UButton
               to="/signup"
               color="neutral"
@@ -196,9 +323,22 @@ onMounted(() => {
             </UButton>
           </div>
           <div
-            v-if="needsCaptcha && !captchaSiteKey.trim() && !loading"
+            v-if="
+              !loading &&
+                !needsCaptcha &&
+                !needsToken &&
+                !needsTerms &&
+                error
+            "
             class="flex flex-col gap-2"
           >
+            <UButton
+              class="w-full justify-center"
+              :loading="loading"
+              @click="runFinalize()"
+            >
+              {{ translateText('auth.signUpRetry') }}
+            </UButton>
             <UButton
               to="/signup"
               color="neutral"

--- a/tests/unit/composables/matrixRegistrationUia.spec.ts
+++ b/tests/unit/composables/matrixRegistrationUia.spec.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildRecaptchaAuthPayload,
+  buildRegistrationTokenAuthPayload,
+  buildTermsAuthPayload,
   extractRecaptchaFromParams,
-  RECAPTCHA_STAGE
+  extractTermsPoliciesFromParams,
+  isRegistrationTokenStage,
+  isTermsStage,
+  pickCompletableEmailSignupFlow,
+  RECAPTCHA_STAGE,
+  TERMS_STAGE
 } from '~/composables/matrix/matrixRegistrationUia'
 
 describe('matrixRegistrationUia', () => {
@@ -52,6 +59,98 @@ describe('matrixRegistrationUia', () => {
         session: 'sess-1',
         response: 'tok'
       })
+    })
+  })
+
+  describe('buildRegistrationTokenAuthPayload', () => {
+    it('sends literal stage id and token field', () => {
+      const unstable =
+        'org.matrix.msc3915.login.registration_token'
+      expect(
+        buildRegistrationTokenAuthPayload('s', ' abc ', unstable)
+      ).toEqual({
+        type: unstable,
+        session: 's',
+        token: 'abc'
+      })
+    })
+  })
+
+  describe('buildTermsAuthPayload', () => {
+    it('only includes type and session', () => {
+      expect(
+        buildTermsAuthPayload('sess', TERMS_STAGE)
+      ).toEqual({
+        type: TERMS_STAGE,
+        session: 'sess'
+      })
+    })
+  })
+
+  describe('isRegistrationTokenStage', () => {
+    it('accepts stable id and unstable suffix', () => {
+      expect(isRegistrationTokenStage('m.login.registration_token'))
+        .toBe(true)
+      expect(
+        isRegistrationTokenStage('org.x.login.registration_token')
+      ).toBe(true)
+      expect(isRegistrationTokenStage('m.login.dummy')).toBe(false)
+    })
+  })
+
+  describe('isTermsStage', () => {
+    it('accepts stable identifier', () => {
+      expect(isTermsStage(TERMS_STAGE)).toBe(true)
+      expect(isTermsStage('org.x.login.terms')).toBe(true)
+    })
+  })
+
+  describe('extractTermsPoliciesFromParams', () => {
+    it('picks preferred locale and parses policy map', () => {
+      const rows = extractTermsPoliciesFromParams(
+        {
+          [TERMS_STAGE]: {
+            policies: {
+              tos: {
+                version: '1',
+                en: {
+                  name: 'ToS',
+                  url: 'https://example.org/tos'
+                }
+              }
+            }
+          }
+        },
+        ['en', 'de']
+      )
+      expect(rows).toEqual([
+        expect.objectContaining({
+          policyId: 'tos',
+          name: 'ToS',
+          url: 'https://example.org/tos',
+          version: '1'
+        })
+      ])
+    })
+  })
+
+  describe('pickCompletableEmailSignupFlow', () => {
+    it('prefers shortest completable email-UIF flow', () => {
+      const result = pickCompletableEmailSignupFlow([
+        { stages: ['m.login.recaptcha', 'm.login.email.identity'] },
+        { stages: ['m.login.email.identity', 'm.login.dummy'] }
+      ])
+      expect(result).toEqual({
+        ok: true,
+        stages: ['m.login.email.identity', 'm.login.dummy']
+      })
+    })
+
+    it('rejects when only SSO email paths exist', () => {
+      const result = pickCompletableEmailSignupFlow([
+        { stages: ['m.login.sso', 'm.login.email.identity'] }
+      ])
+      expect(result).toEqual({ ok: false, reason: 'sso_only' })
     })
   })
 })

--- a/tests/unit/pages/signup-verify-email.spec.ts
+++ b/tests/unit/pages/signup-verify-email.spec.ts
@@ -45,7 +45,15 @@ vi.mock('~/composables/useAppI18n', () => {
           'auth.signUpCaptchaTitle': 'Verify you are human',
           'auth.signUpRecaptchaFailed': 'reCAPTCHA failed',
           'auth.signUpRecaptchaRequired': 'reCAPTCHA required',
-          'auth.signUpRecaptchaMissingSiteKey': 'Missing site key'
+          'auth.signUpRecaptchaMissingSiteKey': 'Missing site key',
+          'auth.signUpRegistrationTokenRequired': 'Token needed',
+          'auth.signUpRegistrationTokenPlaceholder': 'Token placeholder',
+          'auth.signUpRegistrationTokenSubmit': 'Continue token',
+          'auth.signUpRegistrationTokenTitle': 'Token title',
+          'auth.signUpTermsTitle': 'Terms title',
+          'auth.signUpTermsAcceptCheckbox': 'Terms accept',
+          'auth.signUpTermsContinue': 'Terms go',
+          'auth.signUpTermsEmptyPolicies': 'No policy links'
         }
         return messages[key] ?? key
       }
@@ -66,9 +74,20 @@ vi.mock('~/composables/useMatrixClient', () => {
       'SIGNUP_REGISTRATION_UNSUPPORTED_STAGE',
     SIGNUP_RECAPTCHA_FAILED: 'SIGNUP_RECAPTCHA_FAILED',
     SIGNUP_RECAPTCHA_TOKEN_REQUIRED: 'SIGNUP_RECAPTCHA_TOKEN_REQUIRED',
+    SIGNUP_REGISTRATION_TOKEN_REQUIRED:
+      'SIGNUP_REGISTRATION_TOKEN_REQUIRED',
+    SIGNUP_REGISTRATION_TOKEN_REJECTED:
+      'SIGNUP_REGISTRATION_TOKEN_REJECTED',
+    SIGNUP_TERMS_ACCEPTANCE_REQUIRED:
+      'SIGNUP_TERMS_ACCEPTANCE_REQUIRED',
+    SIGNUP_MSISDN_NOT_SUPPORTED: 'SIGNUP_MSISDN_NOT_SUPPORTED',
+    SIGNUP_SSO_USE_WEB_CLIENT: 'SIGNUP_SSO_USE_WEB_CLIENT',
     SIGNUP_PENDING_STORAGE_KEY: PENDING_KEY,
     readSignupPendingPublic: readSignupPendingPublicMock,
     extractRecaptchaFromParams: extractRecaptchaFromParamsMock,
+    hydrateTermsPoliciesForPending: vi.fn(() => []),
+    submitSignupRegistrationToken: vi.fn(async () => undefined),
+    submitSignupTermsAcceptance: vi.fn(async () => undefined),
     useMatrixClient: () => ({ isLoggedIn: ref(false) }),
     finalizeEmailRegistration: finalizeMock
   }
@@ -104,6 +123,30 @@ const SignupRecaptchaStepStub = {
     '<button type="button" class="mock-verify" @click="$emit(\'verified\', \'tok\')">Verify captcha</button>'
 }
 
+const SignupTermsStepStub = {
+  props: ['policies'],
+  emits: ['continue'],
+  template:
+    '<button type="button" class="mock-terms" @click="$emit(\'continue\')">' +
+    'Accept terms</button>'
+}
+
+const UInputStub = {
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  template: `
+    <input
+      class="mock-reg-input"
+      :value="modelValue"
+      @input="$emit('update:modelValue', $event.target.value)"
+    >
+  `
+}
+
+const UFormFieldStub = {
+  template: '<div><slot /></div>'
+}
+
 describe('signup verify-email page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -121,7 +164,10 @@ describe('signup verify-email page', () => {
           UAlert: UAlertStub,
           UButton: UButtonStub,
           NuxtLink: NuxtLinkStub,
-          SignupRecaptchaStep: SignupRecaptchaStepStub
+          UInput: UInputStub,
+          UFormField: UFormFieldStub,
+          SignupRecaptchaStep: SignupRecaptchaStepStub,
+          SignupTermsStep: SignupTermsStepStub
         }
       }
     })
@@ -182,7 +228,8 @@ describe('signup verify-email page', () => {
     await captchaBtn.trigger('click')
     await flushPromises()
     expect(finalizeMock).toHaveBeenLastCalledWith({
-      recaptchaResponse: 'tok'
+      recaptchaResponse: 'tok',
+      registrationToken: null
     })
     expect(navigateToMock).toHaveBeenCalledWith({
       path: '/login',

--- a/tests/unit/pages/signup.spec.ts
+++ b/tests/unit/pages/signup.spec.ts
@@ -88,7 +88,16 @@ vi.mock('~/composables/useAppI18n', () => {
           'auth.signUpPrivacyPolicyLink': 'Privacy',
           'auth.signUpCookieSettings': 'Cookies',
           'auth.signUpAgreeLoadRecaptcha': 'Agree load',
-          'auth.signUpRunRecaptchaCheck': 'Run check'
+          'auth.signUpRunRecaptchaCheck': 'Run check',
+          'cancel': 'Cancel',
+          'auth.signUpRegistrationTokenRequired': 'Registration token hint',
+          'auth.signUpRegistrationTokenPlaceholder':
+            'Paste registration token',
+          'auth.signUpRegistrationTokenSubmit': 'Continue',
+          'auth.signUpRegistrationTokenTitle': 'Registration token',
+          'auth.signUpTermsTitle': 'Policies',
+          'auth.signUpSsoUseWebClient': 'Use Element web SSO',
+          'auth.signUpMsisdnUnsupported': 'SMS signup unsupported'
         }
         return messages[key] ?? key
       }
@@ -103,11 +112,20 @@ vi.mock('~/composables/useMatrixClient', () => {
       'SIGNUP_EMAIL_VERIFICATION_REQUIRED',
     SIGNUP_PENDING_MISSING: 'SIGNUP_PENDING_MISSING',
     SIGNUP_RECAPTCHA_FAILED: 'SIGNUP_RECAPTCHA_FAILED',
+    SIGNUP_RECAPTCHA_TOKEN_REQUIRED: 'SIGNUP_RECAPTCHA_TOKEN_REQUIRED',
     SIGNUP_PENDING_STORAGE_KEY: PENDING_KEY,
     HOMESERVER_CONNECTION_HINT_ERROR: 'HOMESERVER_CONNECTION_HINT',
     SIGNUP_EMAIL_NOT_CONFIRMED_YET: 'SIGNUP_EMAIL_NOT_CONFIRMED_YET',
     SIGNUP_REGISTRATION_UNSUPPORTED_STAGE:
       'SIGNUP_REGISTRATION_UNSUPPORTED_STAGE',
+    SIGNUP_REGISTRATION_TOKEN_REJECTED:
+      'SIGNUP_REGISTRATION_TOKEN_REJECTED',
+    SIGNUP_REGISTRATION_TOKEN_REQUIRED:
+      'SIGNUP_REGISTRATION_TOKEN_REQUIRED',
+    SIGNUP_TERMS_ACCEPTANCE_REQUIRED:
+      'SIGNUP_TERMS_ACCEPTANCE_REQUIRED',
+    SIGNUP_MSISDN_NOT_SUPPORTED: 'SIGNUP_MSISDN_NOT_SUPPORTED',
+    SIGNUP_SSO_USE_WEB_CLIENT: 'SIGNUP_SSO_USE_WEB_CLIENT',
     SIGNUP_SESSION_EXPIRED: 'SIGNUP_SESSION_EXPIRED',
     extractRecaptchaFromParams: mockExtractRecaptchaFromParams,
     readSignupPendingPublic: mockReadSignupPendingPublic,
@@ -120,7 +138,10 @@ vi.mock('~/composables/useMatrixClient', () => {
       isLoggedIn: ref(false)
     }),
     startEmailRegistration: startEmailRegistrationMock,
-    submitSignupRecaptcha: submitSignupRecaptchaMock
+    submitSignupRecaptcha: submitSignupRecaptchaMock,
+    submitSignupRegistrationToken: vi.fn(async () => undefined),
+    submitSignupTermsAcceptance: vi.fn(async () => undefined),
+    hydrateTermsPoliciesForPending: vi.fn(() => [])
   }
 })
 
@@ -170,6 +191,10 @@ const SignupRecaptchaStepStub = {
   template: '<div class="recaptcha-stub">stub</div>'
 }
 
+const SignupTermsStepStub = {
+  template: '<div class="terms-stub"></div>'
+}
+
 describe('signup page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -192,7 +217,8 @@ describe('signup page', () => {
           UButton: UButtonStub,
           NuxtLink: NuxtLinkStub,
           ClientOnly: ClientOnlyStub,
-          SignupRecaptchaStep: SignupRecaptchaStepStub
+          SignupRecaptchaStep: SignupRecaptchaStepStub,
+          SignupTermsStep: SignupTermsStepStub
         }
       }
     })


### PR DESCRIPTION
- Introduce a new registration token stage in the signup flow, allowing users to input a token before proceeding.
- Implement terms acceptance as a required step, with a dedicated `SignupTermsStep` component for policy review.
- Update `useMatrixClient` to manage new signup states and handle errors related to registration tokens and terms acceptance.
- Enhance translations in `useAppI18n` for new messages related to registration tokens and terms.
- Update the signup and verify-email pages to accommodate the new flow, ensuring proper navigation and error handling.
- Add unit tests to cover the new registration token and terms acceptance functionalities, ensuring robust testing of the signup process.
- Document changes in the CHANGELOG to reflect the enhancements in the signup process.