### PR TITLE
Enhance chat timeline with immediate message visibility and preserved…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sent messages now appear immediately at the bottom of the room timeline
+  without manual scrolling by extending the visible window and scroll intent
+  when the user was already at the latest events (#76)
 - Space-to-room parent mapping now uses Matrix `m.space.parent` state
 - Space avatar resolution now supports Matrix mxc avatar URLs with fallback
 - Homeserver base URL normalization now upgrades public http to https to avoid

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -14,6 +14,7 @@ import {
   buildReactionSummaryByEventId,
   buildRoomThreadNavEntries,
   mapTimelineEventsToMessages,
+  resolvePreservedTimelineWindow,
   resolveTimelineWindowSelection,
   type ThreadNavEntry,
 } from "~/utils/chatTimeline";
@@ -886,6 +887,9 @@ function loadMessages(
   const previousVisibleIds = new Set(
     previousVisibleMessages.map((message) => message.id),
   );
+  const previousEventCount = allMessages.value.length;
+  const previousWindowStartIndex = windowStartIndex.value;
+  const previousWindowEndIndex = windowEndIndex.value;
   const mappedMessages = mapTimelineEventsToMessages({
     room,
     ownUserId: client.value?.getUserId() ?? undefined,
@@ -949,27 +953,24 @@ function loadMessages(
     }
   }
 
-  const previousFirstMessageId = previousVisibleMessages[0]?.id;
-  const previousLastMessageId =
-    previousVisibleMessages[previousVisibleMessages.length - 1]?.id;
-  const nextStartIndex = previousFirstMessageId
-    ? mappedMessages.findIndex((message) => message.id === previousFirstMessageId)
-    : -1;
-  const nextLastIndex = previousLastMessageId
-    ? mappedMessages.findIndex((message) => message.id === previousLastMessageId)
-    : -1;
-  if (nextStartIndex >= 0 && nextLastIndex >= nextStartIndex) {
-    windowStartIndex.value = nextStartIndex;
-    windowEndIndex.value = nextLastIndex + 1;
-  } else {
-    const fallbackSelection = resolveTimelineWindowSelection(
-      mappedMessages.map((message) => message.id),
-      { windowSize: INITIAL_TIMELINE_WINDOW_SIZE },
-    );
-    windowStartIndex.value = fallbackSelection.startIndex;
-    windowEndIndex.value = fallbackSelection.endIndex;
-  }
+  const preservedWindow = resolvePreservedTimelineWindow({
+    previousStartIndex: previousWindowStartIndex,
+    previousEndIndex: previousWindowEndIndex,
+    previousEventCount,
+    previousFirstMessageId: previousVisibleMessages[0]?.id,
+    previousLastMessageId:
+      previousVisibleMessages[previousVisibleMessages.length - 1]?.id,
+    nextEventIds: mappedMessages.map((message) => message.id),
+    windowSize: INITIAL_TIMELINE_WINDOW_SIZE,
+    stickToBottom: stickToBottom.value,
+  });
+  windowStartIndex.value = preservedWindow.startIndex;
+  windowEndIndex.value = preservedWindow.endIndex;
   applyWindow();
+  if (preservedWindow.shouldScrollToBottom) {
+    centerOnMessageId.value = undefined;
+    scrollIntentToken.value += 1;
+  }
   syncThreadPanelIfActive(roomId);
   scheduleThreadNavRefresh();
 }
@@ -1043,6 +1044,9 @@ function onComposerSend() {
   if (loadMessagesTimerId.value !== null) {
     window.clearTimeout(loadMessagesTimerId.value);
     loadMessagesTimerId.value = null;
+  }
+  if (windowEndIndex.value >= allMessages.value.length) {
+    stickToBottom.value = true;
   }
   loadMessages(roomId, { resetWindow: false });
   syncThreadPanelIfActive(roomId);

--- a/app/utils/chatTimeline.ts
+++ b/app/utils/chatTimeline.ts
@@ -81,6 +81,23 @@ export interface TimelineWindowSelection {
   anchorFound: boolean
 }
 
+export interface PreservedTimelineWindowInput {
+  previousStartIndex: number
+  previousEndIndex: number
+  previousEventCount: number
+  previousFirstMessageId?: string
+  previousLastMessageId?: string
+  nextEventIds: string[]
+  windowSize: number
+  stickToBottom: boolean
+}
+
+export interface PreservedTimelineWindowSelection {
+  startIndex: number
+  endIndex: number
+  shouldScrollToBottom: boolean
+}
+
 interface MapTimelineArgs {
   room: Record<string, any>
   ownUserId: string | undefined
@@ -841,6 +858,56 @@ export function resolveTimelineWindowSelection(
     endIndex,
     anchorIndex,
     anchorFound: true
+  }
+}
+
+export function resolvePreservedTimelineWindow(
+  input: PreservedTimelineWindowInput
+): PreservedTimelineWindowSelection {
+  const {
+    previousEndIndex,
+    previousEventCount,
+    previousFirstMessageId,
+    previousLastMessageId,
+    nextEventIds,
+    windowSize,
+    stickToBottom
+  } = input
+
+  const totalEvents = nextEventIds.length
+  const wasShowingLatest = previousEndIndex >= previousEventCount
+
+  const nextStartIndex = previousFirstMessageId
+    ? nextEventIds.findIndex((eventId) => eventId === previousFirstMessageId)
+    : -1
+  const nextLastIndex = previousLastMessageId
+    ? nextEventIds.findIndex((eventId) => eventId === previousLastMessageId)
+    : -1
+
+  let startIndex: number
+  let endIndex: number
+
+  if (nextStartIndex >= 0 && nextLastIndex >= nextStartIndex) {
+    startIndex = nextStartIndex
+    endIndex = nextLastIndex + 1
+  } else {
+    const fallbackSelection = resolveTimelineWindowSelection(nextEventIds, {
+      windowSize
+    })
+    startIndex = fallbackSelection.startIndex
+    endIndex = fallbackSelection.endIndex
+  }
+
+  if (wasShowingLatest || stickToBottom) {
+    endIndex = totalEvents
+  }
+
+  const shouldScrollToBottom = stickToBottom && wasShowingLatest
+
+  return {
+    startIndex,
+    endIndex,
+    shouldScrollToBottom
   }
 }
 

--- a/tests/e2e/features/chat.feature
+++ b/tests/e2e/features/chat.feature
@@ -62,6 +62,13 @@ Feature: Chat
     When I close the thread side panel
     Then I should not see the thread side panel
 
+  Scenario: Sent message appears immediately without manual scroll
+    When I open the login page
+    And I sign in with configured credentials
+    And I open the seeded test room
+    When I send "E2E_SEND_VISIBLE_IMMEDIATE" from the message composer
+    Then I should see message body "E2E_SEND_VISIBLE_IMMEDIATE"
+
   Scenario: Edit sent message and persist after reload
     When I open the login page
     And I sign in with configured credentials

--- a/tests/integration/utils/chatTimeline.spec.ts
+++ b/tests/integration/utils/chatTimeline.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest'
 import {
   mapTimelineEventsToMessages,
+  resolvePreservedTimelineWindow,
   resolveTimelineWindowSelection
 } from '~/utils/chatTimeline'
 
@@ -284,5 +285,31 @@ describe('chatTimeline integration', () => {
     selection.startIndex.should.equal(1)
     selection.endIndex.should.equal(5)
     selection.anchorFound.should.equal(true)
+  })
+
+  it('extends preserved window when user was at timeline end', () => {
+    const selection = resolvePreservedTimelineWindow({
+      previousStartIndex: 2,
+      previousEndIndex: 8,
+      previousEventCount: 8,
+      previousFirstMessageId: 'evt3',
+      previousLastMessageId: 'evt8',
+      nextEventIds: [
+        'evt1',
+        'evt2',
+        'evt3',
+        'evt4',
+        'evt5',
+        'evt6',
+        'evt7',
+        'evt8',
+        'evt9'
+      ],
+      windowSize: 80,
+      stickToBottom: true
+    })
+    selection.startIndex.should.equal(2)
+    selection.endIndex.should.equal(9)
+    selection.shouldScrollToBottom.should.equal(true)
   })
 })

--- a/tests/unit/utils/chatTimeline.spec.ts
+++ b/tests/unit/utils/chatTimeline.spec.ts
@@ -9,6 +9,7 @@ import {
   isRedactedMessageEvent,
   isUndecryptableEvent,
   mapTimelineEventsToMessages,
+  resolvePreservedTimelineWindow,
   resolveTimelineWindowSelection
 } from '~/utils/chatTimeline'
 
@@ -670,6 +671,79 @@ describe('chatTimeline helpers', () => {
     selection.endIndex.should.equal(3)
     selection.anchorFound.should.equal(false)
     ;(selection.anchorIndex === null).should.equal(true)
+  })
+
+  it('extends window to latest when append at bottom', () => {
+    const selection = resolvePreservedTimelineWindow({
+      previousStartIndex: 0,
+      previousEndIndex: 5,
+      previousEventCount: 5,
+      previousFirstMessageId: 'evt1',
+      previousLastMessageId: 'evt5',
+      nextEventIds: ['evt1', 'evt2', 'evt3', 'evt4', 'evt5', 'evt6'],
+      windowSize: 80,
+      stickToBottom: true
+    })
+    selection.startIndex.should.equal(0)
+    selection.endIndex.should.equal(6)
+    selection.shouldScrollToBottom.should.equal(true)
+  })
+
+  it('does not extend window when scrolled above latest', () => {
+    const selection = resolvePreservedTimelineWindow({
+      previousStartIndex: 0,
+      previousEndIndex: 3,
+      previousEventCount: 10,
+      previousFirstMessageId: 'evt1',
+      previousLastMessageId: 'evt3',
+      nextEventIds: [
+        'evt1',
+        'evt2',
+        'evt3',
+        'evt4',
+        'evt5',
+        'evt6',
+        'evt7',
+        'evt8',
+        'evt9',
+        'evt10',
+        'evt11'
+      ],
+      windowSize: 80,
+      stickToBottom: false
+    })
+    selection.startIndex.should.equal(0)
+    selection.endIndex.should.equal(3)
+    selection.shouldScrollToBottom.should.equal(false)
+  })
+
+  it('extends window without scroll when latest but not stickToBottom', () => {
+    const selection = resolvePreservedTimelineWindow({
+      previousStartIndex: 0,
+      previousEndIndex: 3,
+      previousEventCount: 3,
+      previousFirstMessageId: 'evt1',
+      previousLastMessageId: 'evt3',
+      nextEventIds: ['evt1', 'evt2', 'evt3', 'evt4'],
+      windowSize: 80,
+      stickToBottom: false
+    })
+    selection.endIndex.should.equal(4)
+    selection.shouldScrollToBottom.should.equal(false)
+  })
+
+  it('uses fallback window when previous ids are missing', () => {
+    const selection = resolvePreservedTimelineWindow({
+      previousStartIndex: 0,
+      previousEndIndex: 2,
+      previousEventCount: 10,
+      nextEventIds: ['evt1', 'evt2', 'evt3', 'evt4', 'evt5'],
+      windowSize: 3,
+      stickToBottom: false
+    })
+    selection.startIndex.should.equal(2)
+    selection.endIndex.should.equal(5)
+    selection.shouldScrollToBottom.should.equal(false)
   })
 
   it('excludes MSC3440 thread replies from main timeline', () => {


### PR DESCRIPTION
… scrolling behavior

- Implemented functionality to ensure sent messages appear immediately at the bottom of the room timeline without requiring manual scrolling.
- Extended the visible window and scroll intent when the user is already viewing the latest events, improving user experience during message sending.
- Updated `loadMessages` function in `chat.vue` to utilize a new utility for preserving timeline window state.
- Added integration and unit tests to verify the new behavior of message visibility and scrolling.
- Updated CHANGELOG to reflect the enhancements in message visibility and scrolling behavior.