### PR TITLE
Implement typing indicators in chat components (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Typing indicators in the active room: receive `m.typing` via the SDK,
+  debounced outbound `sendTyping` from the composer, compact label above the
+  message input (EN/DE), and multi-user summaries (#77)
 - Reply quotes show image and video previews in the timeline and composer,
   and clicking a quote scrolls to and highlights the original message (#83)
 - Emoji picker and colon shortcode autocomplete in the message composer

--- a/app/components/Chat/ChatTypingIndicator.vue
+++ b/app/components/Chat/ChatTypingIndicator.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+defineProps<{
+  label: string | null
+}>()
+</script>
+
+<template>
+  <p
+    v-if="label"
+    data-testid="typing-indicator"
+    aria-live="polite"
+    class="truncate px-4 pb-1 text-xs text-gray-500 dark:text-gray-400"
+  >
+    {{ label }}
+  </p>
+</template>

--- a/app/components/Chat/MessageInput.vue
+++ b/app/components/Chat/MessageInput.vue
@@ -25,6 +25,7 @@ import {
   matchShortcodeSuggestions,
   type ShortcodeSuggestion,
 } from '~/utils/composerEmoji'
+import { createComposerTypingNotifier } from '~/utils/composerTypingNotifier'
 
 const message = ref('')
 const loading = ref(false)
@@ -58,7 +59,21 @@ const emit = defineEmits<{
   cancelEdit: []
 }>()
 
-const { client, sendMessage, sendEditMessage, sendImageMessage } = useMatrixClient()
+const {
+  client,
+  sendMessage,
+  sendEditMessage,
+  sendImageMessage,
+  sendRoomTyping,
+} = useMatrixClient()
+
+const typingNotifier = createComposerTypingNotifier({
+  getRoomId: () => props.roomId,
+  sendTyping: sendRoomTyping,
+  isEnabled: () => Boolean(
+    props.roomId && !props.disabled && client?.value,
+  ),
+})
 const { translateText } = useAppI18n()
 const { resolveMediaBlobUrl } = useChatMedia(client)
 const composerReplyDisplayUrl = ref<string | undefined>()
@@ -156,6 +171,9 @@ function insertEmojiAtCursor(emoji: string) {
   message.value = nextText
   clearAutocomplete()
   nextTick(() => setInputSelection(selectionStart))
+  if (nextText.trim()) {
+    typingNotifier.notifyInput()
+  }
 }
 
 function onPickerSelect(emoji: string) {
@@ -209,10 +227,18 @@ function applyActiveSuggestion() {
   message.value = nextText
   clearAutocomplete()
   nextTick(() => setInputSelection(selectionStart))
+  if (nextText.trim()) {
+    typingNotifier.notifyInput()
+  }
 }
 
 function onMessageInput() {
   refreshAutocomplete()
+  if (message.value.trim()) {
+    typingNotifier.notifyInput()
+  } else {
+    typingNotifier.notifyStopped()
+  }
 }
 
 function onMessageKeydown(event: KeyboardEvent) {
@@ -270,11 +296,30 @@ if (import.meta.client) {
 }
 
 onBeforeUnmount(() => {
+  typingNotifier.notifyStopped()
   if (!import.meta.client) {
     return
   }
   document.removeEventListener('click', onDocumentClick)
 })
+
+watch(
+  () => props.roomId,
+  (_nextRoomId, previousRoomId) => {
+    if (previousRoomId) {
+      typingNotifier.notifyStopped()
+    }
+  },
+)
+
+watch(
+  () => props.disabled,
+  (isDisabled) => {
+    if (isDisabled) {
+      typingNotifier.notifyStopped()
+    }
+  },
+)
 
 async function handleSend() {
   const body = normalizeShortcodes(
@@ -285,6 +330,7 @@ async function handleSend() {
     return
   }
 
+  typingNotifier.notifyStopped()
   loading.value = true
   clearAutocomplete()
   pickerOpen.value = false

--- a/app/composables/useAppI18n.ts
+++ b/app/composables/useAppI18n.ts
@@ -159,6 +159,10 @@ const messages: Record<AppLocale, Record<string, string>> = {
     'chat.insertEmoji': 'Insert emoji',
     'chat.emojiAutocompleteHint': 'Emoji shortcode suggestions',
     'chat.messagePlaceholder': 'Write a message...',
+    'chat.typingOne': '{name} is typing…',
+    'chat.typingTwo': '{first} and {second} are typing…',
+    'chat.typingManyOneOther': '{first}, {second} and 1 other are typing…',
+    'chat.typingManyOthers': '{first}, {second} and {count} others are typing…',
     'chat.noRooms': 'No rooms',
     'layout.spaces': 'Spaces',
     'layout.channels': 'Channels',
@@ -504,6 +508,12 @@ const messages: Record<AppLocale, Record<string, string>> = {
     'chat.insertEmoji': 'Emoji einfügen',
     'chat.emojiAutocompleteHint': 'Emoji-Shortcode-Vorschläge',
     'chat.messagePlaceholder': 'Nachricht eingeben...',
+    'chat.typingOne': '{name} schreibt…',
+    'chat.typingTwo': '{first} und {second} schreiben…',
+    'chat.typingManyOneOther':
+      '{first}, {second} und 1 weitere Person schreiben…',
+    'chat.typingManyOthers':
+      '{first}, {second} und {count} weitere schreiben…',
     'chat.noRooms': 'Keine Räume',
     'layout.spaces': 'Spaces',
     'layout.channels': 'Kanäle',

--- a/app/composables/useMatrixClient.ts
+++ b/app/composables/useMatrixClient.ts
@@ -1077,6 +1077,17 @@ export function useMatrixClient() {
     }
   }
 
+  async function sendRoomTyping(
+    roomId: string,
+    isTyping: boolean,
+    timeoutMs: number,
+  ): Promise<void> {
+    if (!client.value) {
+      return
+    }
+    await client.value.sendTyping(roomId, isTyping, timeoutMs)
+  }
+
   async function sendMessage(
     roomId: string,
     body: string,
@@ -1572,6 +1583,7 @@ export function useMatrixClient() {
     getRooms,
     getRoom,
     markRoomAsRead,
+    sendRoomTyping,
     sendMessage,
     sendEditMessage,
     sendImageMessage,

--- a/app/composables/useRoomTyping.ts
+++ b/app/composables/useRoomTyping.ts
@@ -1,0 +1,71 @@
+import { RoomMemberEvent } from 'matrix-js-sdk'
+import type { MatrixClient } from 'matrix-js-sdk'
+import { useAppI18n } from '~/composables/useAppI18n'
+import {
+  buildTypingIndicatorLabel,
+  getTypingMembers,
+} from '~/utils/typingIndicator'
+
+export function useRoomTyping(options: {
+  client: Ref<MatrixClient | null>
+  selectedRoomId: Ref<string | null>
+  userId: Ref<string | null | undefined>
+}) {
+  const { translateText } = useAppI18n()
+  const typingVersion = ref(0)
+
+  function refreshTyping(): void {
+    typingVersion.value += 1
+  }
+
+  const typingLabel = computed(() => {
+    typingVersion.value
+    const roomId = options.selectedRoomId.value
+    const matrixClient = options.client.value
+    if (!roomId || !matrixClient) {
+      return null
+    }
+    const room = matrixClient.getRoom(roomId)
+    if (!room) {
+      return null
+    }
+    const members = getTypingMembers(
+      room as never,
+      options.userId.value ?? null,
+    )
+    return buildTypingIndicatorLabel(members, translateText)
+  })
+
+  watch(
+    () => options.selectedRoomId.value,
+    () => {
+      refreshTyping()
+    },
+  )
+
+  watch(
+    () => options.client.value,
+    (matrixClient, _previousClient, onCleanup) => {
+      if (!matrixClient) {
+        return
+      }
+
+      const typingHandler = (
+        _event: unknown,
+        member: { roomId?: string },
+      ): void => {
+        if (member.roomId === options.selectedRoomId.value) {
+          refreshTyping()
+        }
+      }
+
+      matrixClient.on(RoomMemberEvent.Typing, typingHandler)
+      onCleanup(() => {
+        matrixClient.off(RoomMemberEvent.Typing, typingHandler)
+      })
+    },
+    { immediate: true },
+  )
+
+  return { typingLabel }
+}

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -7,6 +7,7 @@ import {
 } from "matrix-js-sdk";
 import { useAppI18n } from "~/composables/useAppI18n";
 import { useChatMedia } from "~/composables/useChatMedia";
+import { useRoomTyping } from "~/composables/useRoomTyping";
 import ChatOnboardingPanel from "~/components/Chat/Onboarding/ChatOnboardingPanel.vue";
 import ChatDmStartPanel from "~/components/Chat/Onboarding/ChatDmStartPanel.vue";
 import ChatPublicRoomsPanel from "~/components/Chat/Onboarding/ChatPublicRoomsPanel.vue";
@@ -180,6 +181,11 @@ const {
   matrixRooms,
   selectedRoomId,
   markRoomAsRead,
+});
+const { typingLabel } = useRoomTyping({
+  client,
+  selectedRoomId,
+  userId,
 });
 const loadingOlder = ref(false);
 const loadingNewer = ref(false);
@@ -1806,6 +1812,7 @@ watch(
             @open-reply-target="jumpToMessageInThread"
             @toggle-reaction="onToggleReaction"
           />
+          <ChatTypingIndicator :label="typingLabel" />
           <ChatMessageInput
             :room-id="selectedRoomId"
             :disabled="!client"
@@ -1842,6 +1849,12 @@ watch(
             @open-thread-preview="openThreadInSidebar"
             @open-reply-target="jumpToMessageInRoom"
             @toggle-reaction="onToggleReaction"
+          />
+          <ChatTypingIndicator
+            v-if="
+              !activeThread || activeThread.presentation !== 'sidebar'
+            "
+            :label="typingLabel"
           />
           <ChatMessageInput
             v-if="

--- a/app/utils/composerTypingNotifier.ts
+++ b/app/utils/composerTypingNotifier.ts
@@ -1,0 +1,109 @@
+export const TYPING_SERVER_TIMEOUT_MS = 30_000
+/** Must be greater than {@link TYPING_REFRESH_MS} so refresh can extend typing. */
+export const TYPING_IDLE_MS = 12_000
+export const TYPING_REFRESH_MS = 5_000
+
+export type SendTypingFn = (
+  roomId: string,
+  isTyping: boolean,
+  timeoutMs: number,
+) => Promise<unknown>
+
+export interface ComposerTypingNotifierOptions {
+  getRoomId: () => string | null
+  sendTyping: SendTypingFn
+  isEnabled: () => boolean
+}
+
+export interface ComposerTypingNotifier {
+  notifyInput: () => void
+  notifyStopped: () => void
+}
+
+export function createComposerTypingNotifier(
+  options: ComposerTypingNotifierOptions,
+): ComposerTypingNotifier {
+  let isTypingActive = false
+  let idleTimerId: ReturnType<typeof setTimeout> | null = null
+  let refreshTimerId: ReturnType<typeof setTimeout> | null = null
+
+  function clearIdleTimer(): void {
+    if (idleTimerId !== null) {
+      clearTimeout(idleTimerId)
+      idleTimerId = null
+    }
+  }
+
+  function clearRefreshTimer(): void {
+    if (refreshTimerId !== null) {
+      clearTimeout(refreshTimerId)
+      refreshTimerId = null
+    }
+  }
+
+  function clearTimers(): void {
+    clearIdleTimer()
+    clearRefreshTimer()
+  }
+
+  async function publishTyping(isTyping: boolean): Promise<void> {
+    const roomId = options.getRoomId()
+    if (!roomId || !options.isEnabled()) {
+      return
+    }
+    try {
+      await options.sendTyping(
+        roomId,
+        isTyping,
+        TYPING_SERVER_TIMEOUT_MS,
+      )
+    } catch {
+      // Homeserver may disable typing; fail silently.
+    }
+  }
+
+  function scheduleRefresh(): void {
+    clearRefreshTimer()
+    refreshTimerId = setTimeout(() => {
+      refreshTimerId = null
+      if (!isTypingActive) {
+        return
+      }
+      void publishTyping(true)
+      scheduleRefresh()
+    }, TYPING_REFRESH_MS)
+  }
+
+  function scheduleIdleStop(): void {
+    clearIdleTimer()
+    idleTimerId = setTimeout(() => {
+      idleTimerId = null
+      notifyStopped()
+    }, TYPING_IDLE_MS)
+  }
+
+  function notifyInput(): void {
+    if (!options.isEnabled() || !options.getRoomId()) {
+      return
+    }
+    scheduleIdleStop()
+    if (isTypingActive) {
+      scheduleRefresh()
+      return
+    }
+    isTypingActive = true
+    void publishTyping(true)
+    scheduleRefresh()
+  }
+
+  function notifyStopped(): void {
+    clearTimers()
+    if (!isTypingActive) {
+      return
+    }
+    isTypingActive = false
+    void publishTyping(false)
+  }
+
+  return { notifyInput, notifyStopped }
+}

--- a/app/utils/typingIndicator.ts
+++ b/app/utils/typingIndicator.ts
@@ -1,0 +1,74 @@
+export type TypingTranslateFn = (
+  key: string,
+  placeholders?: Record<string, string>,
+) => string
+
+export interface TypingMemberLike {
+  userId?: string
+  name?: string
+  typing?: boolean
+  membership?: string
+}
+
+export interface TypingRoomLike {
+  getMembers?: () => TypingMemberLike[]
+}
+
+export function resolveTypingDisplayName(
+  member: TypingMemberLike,
+): string {
+  const userId = String(member.userId ?? '')
+  return String(member.name || userId)
+}
+
+export function getTypingMembers(
+  room: TypingRoomLike | null | undefined,
+  currentUserId: string | null | undefined,
+): TypingMemberLike[] {
+  if (!room?.getMembers) {
+    return []
+  }
+  const selfId = currentUserId ?? ''
+  return room
+    .getMembers()
+    .filter((member) => {
+      if (!member.typing) {
+        return false
+      }
+      if (member.membership && member.membership !== 'join') {
+        return false
+      }
+      const memberId = String(member.userId ?? '')
+      return memberId.length > 0 && memberId !== selfId
+    })
+}
+
+export function buildTypingIndicatorLabel(
+  members: TypingMemberLike[],
+  translateText: TypingTranslateFn,
+): string | null {
+  const names = members.map((member) => resolveTypingDisplayName(member))
+  if (names.length === 0) {
+    return null
+  }
+  if (names.length === 1) {
+    return translateText('chat.typingOne', { name: names[0]! })
+  }
+  if (names.length === 2) {
+    return translateText('chat.typingTwo', {
+      first: names[0]!,
+      second: names[1]!,
+    })
+  }
+  const first = names[0]!
+  const second = names[1]!
+  const othersCount = names.length - 2
+  if (othersCount === 1) {
+    return translateText('chat.typingManyOneOther', { first, second })
+  }
+  return translateText('chat.typingManyOthers', {
+    first,
+    second,
+    count: String(othersCount),
+  })
+}

--- a/tests/e2e/features/chat.feature
+++ b/tests/e2e/features/chat.feature
@@ -181,6 +181,15 @@ Feature: Chat
     When I remove reaction "👍" on message body "E2E_SEED_BASE_MESSAGE"
     Then I should not see reaction "👍" on message body "E2E_SEED_BASE_MESSAGE"
 
+  Scenario: Typing indicator when another user composes
+    When I open the login page
+    And I sign in with configured credentials
+    And I open the seeded test room
+    And the secondary user starts typing in the main test room
+    Then the typing indicator should be visible
+    When the secondary user stops typing in the main test room
+    Then the typing indicator should not be visible
+
   Scenario Outline: Member presence indicator reflects standard status
     When I open the login page
     And I sign in with configured credentials

--- a/tests/e2e/step-definitions/typing-indicator.steps.mjs
+++ b/tests/e2e/step-definitions/typing-indicator.steps.mjs
@@ -1,0 +1,93 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+
+function requireEnv(variableName) {
+  const variableValue = process.env[variableName]
+  if (!variableValue) {
+    throw new Error(`Missing required E2E env: ${variableName}`)
+  }
+  return variableValue
+}
+
+function matrixHomeserverUrl() {
+  return requireEnv('E2E_MATRIX_HOMESERVER').replace(/\/$/, '')
+}
+
+async function fetchSecondaryAccessToken() {
+  const homeserver = matrixHomeserverUrl()
+  const userId = requireEnv('E2E_SECOND_MATRIX_USERNAME')
+  const password = requireEnv('E2E_SECOND_MATRIX_PASSWORD')
+  const localpart = userId.startsWith('@')
+    ? userId.slice(1).split(':')[0]
+    : userId
+
+  const response = await fetch(`${homeserver}/_matrix/client/v3/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      type: 'm.login.password',
+      identifier: { type: 'm.id.user', user: localpart },
+      password,
+    }),
+  })
+  const bodyText = await response.text()
+  const body = bodyText ? JSON.parse(bodyText) : {}
+  if (!response.ok || !body.access_token) {
+    throw new Error('Secondary Matrix login failed for typing E2E step')
+  }
+  return { accessToken: body.access_token, userId }
+}
+
+async function setSecondaryTyping(isTyping) {
+  const homeserver = matrixHomeserverUrl()
+  const roomId = requireEnv('E2E_TEST_ROOM_ID')
+  const { accessToken, userId } = await fetchSecondaryAccessToken()
+  const encodedRoomId = encodeURIComponent(roomId)
+  const encodedUserId = encodeURIComponent(userId)
+  const body = isTyping
+    ? JSON.stringify({ typing: true, timeout: 30_000 })
+    : JSON.stringify({ typing: false })
+  const response = await fetch(
+    `${homeserver}/_matrix/client/v3/rooms/${encodedRoomId}`
+      + `/typing/${encodedUserId}`,
+    {
+      method: 'PUT',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        'content-type': 'application/json',
+      },
+      body,
+    },
+  )
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(
+      `Secondary typing update failed (${response.status}): ${errorText}`,
+    )
+  }
+}
+
+When(
+  'the secondary user starts typing in the main test room',
+  async function () {
+    await setSecondaryTyping(true)
+  },
+)
+
+When(
+  'the secondary user stops typing in the main test room',
+  async function () {
+    await setSecondaryTyping(false)
+  },
+)
+
+Then('the typing indicator should be visible', async function () {
+  const indicator = this.page.getByTestId('typing-indicator')
+  await expect(indicator).toBeVisible({ timeout: 15_000 })
+  await expect(indicator).toHaveText(/typing|schreibt/i)
+})
+
+Then('the typing indicator should not be visible', async function () {
+  const indicator = this.page.getByTestId('typing-indicator')
+  await expect(indicator).toHaveCount(0, { timeout: 15_000 })
+})

--- a/tests/unit/components/Chat/MessageInput.spec.ts
+++ b/tests/unit/components/Chat/MessageInput.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi } from 'vitest'
+import { beforeEach, describe, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import ChatMessageInput from '~/components/Chat/MessageInput.vue'
 
@@ -74,15 +74,30 @@ function mountInput(
   })
 }
 
+function defaultMatrixClientStub(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    client: { value: {} },
+    sendMessage: vi.fn(async () => undefined),
+    sendEditMessage: vi.fn(async () => undefined),
+    sendImageMessage: vi.fn(async () => undefined),
+    sendRoomTyping: vi.fn(async () => undefined),
+    ...overrides,
+  }
+}
+
 describe('MessageInput', () => {
+  beforeEach(() => {
+    ;(globalThis as Record<string, unknown>).useMatrixClient =
+      () => defaultMatrixClientStub()
+  })
+
   it('sends image from file picker', async () => {
     const sendImageMessage = vi.fn(async () => undefined)
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage, sendImageMessage })
 
     const wrapper = mountInput()
     const imageFile = new File(['img-data'], 'picked.png', {
@@ -104,11 +119,8 @@ describe('MessageInput', () => {
   it('sends image from clipboard paste', async () => {
     const sendImageMessage = vi.fn(async () => undefined)
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage, sendImageMessage })
 
     const wrapper = mountInput()
     const pastedFile = new File(['img-data'], 'pasted.png', {
@@ -137,11 +149,8 @@ describe('MessageInput', () => {
   it('ignores non-image clipboard data', async () => {
     const sendImageMessage = vi.fn(async () => undefined)
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage, sendImageMessage })
 
     const wrapper = mountInput()
     const input = wrapper.find('input[type="text"]')
@@ -164,11 +173,8 @@ describe('MessageInput', () => {
   it('sends reply message with in-reply-to payload', async () => {
     const sendImageMessage = vi.fn(async () => undefined)
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage, sendImageMessage })
 
     const wrapper = mountInput({
       replyTo: {
@@ -193,11 +199,8 @@ describe('MessageInput', () => {
   it('emits cancelReply when clicking cancel button', async () => {
     const sendImageMessage = vi.fn(async () => undefined)
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage, sendImageMessage })
 
     const wrapper = mountInput({
       replyTo: {
@@ -220,11 +223,8 @@ describe('MessageInput', () => {
   it('sends thread reply with threadRootEventId and replyTo', async () => {
     const sendImageMessage = vi.fn(async () => undefined)
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage, sendImageMessage })
 
     const wrapper = mountInput({
       threadRootEventId: '$root-event',
@@ -248,11 +248,8 @@ describe('MessageInput', () => {
   it('prefills and sends edit message with sendEditMessage', async () => {
     const sendEditMessage = vi.fn(async () => undefined)
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage,
-      sendImageMessage: vi.fn(async () => undefined)
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage, sendEditMessage })
 
     const wrapper = mountInput({
       editTo: {
@@ -276,11 +273,8 @@ describe('MessageInput', () => {
   })
 
   it('emits cancelEdit when clicking cancel edit button', async () => {
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage: vi.fn(async () => undefined),
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage: vi.fn(async () => undefined)
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient =
+      () => defaultMatrixClientStub()
 
     const wrapper = mountInput({
       editTo: {
@@ -302,11 +296,8 @@ describe('MessageInput', () => {
 
   it('opens picker and inserts emoji without sending', async () => {
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage: vi.fn(async () => undefined)
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage })
 
     const wrapper = mountInput()
     await wrapper.get('[data-testid="composer-emoji-button"]').trigger('click')
@@ -322,11 +313,8 @@ describe('MessageInput', () => {
 
   it('autocompletes see_no shortcode with Tab', async () => {
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage: vi.fn(async () => undefined)
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage })
 
     const wrapper = mountInput()
     const input = wrapper.find('input[type="text"]')
@@ -339,11 +327,8 @@ describe('MessageInput', () => {
 
   it('does not send when Enter completes autocomplete', async () => {
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage: vi.fn(async () => undefined)
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage })
 
     const wrapper = mountInput()
     const input = wrapper.find('input[type="text"]')
@@ -356,11 +341,8 @@ describe('MessageInput', () => {
 
   it('normalizes full shortcode on send', async () => {
     const sendMessage = vi.fn(async () => undefined)
-    ;(globalThis as Record<string, unknown>).useMatrixClient = () => ({
-      sendMessage,
-      sendEditMessage: vi.fn(async () => undefined),
-      sendImageMessage: vi.fn(async () => undefined)
-    })
+    ;(globalThis as Record<string, unknown>).useMatrixClient = () =>
+      defaultMatrixClientStub({ sendMessage })
 
     const wrapper = mountInput()
     await wrapper.find('input[type="text"]').setValue(':see_no_evil:')

--- a/tests/unit/composables/useRoomTyping.spec.ts
+++ b/tests/unit/composables/useRoomTyping.spec.ts
@@ -1,0 +1,94 @@
+import { ref } from 'vue'
+import { describe, it, vi } from 'vitest'
+import { RoomMemberEvent } from 'matrix-js-sdk'
+import { useRoomTyping } from '~/composables/useRoomTyping'
+
+vi.mock('~/composables/useAppI18n', () => ({
+  useAppI18n: () => ({
+    translateText: (key: string, placeholders?: Record<string, string>) => {
+      if (key === 'chat.typingOne') {
+        return `${placeholders?.name} is typing…`
+      }
+      return key
+    },
+  }),
+}))
+
+function mockRoom(members: Array<Record<string, unknown>>) {
+  return {
+    getMembers: () => members,
+  }
+}
+
+describe('useRoomTyping', () => {
+  it('updates label when RoomMemberEvent.Typing fires', () => {
+    const handlers: Record<string, (event: unknown, member: unknown) => void> =
+      {}
+    let bobIsTyping = false
+    const matrixClient = {
+      getRoom: vi.fn(() =>
+        mockRoom([
+          {
+            userId: '@bob:example.org',
+            name: 'Bob',
+            get typing() {
+              return bobIsTyping
+            },
+            membership: 'join',
+          },
+        ]),
+      ),
+      on: vi.fn((eventName: string, handler: typeof handlers[string]) => {
+        handlers[eventName] = handler
+      }),
+      off: vi.fn(),
+    }
+
+    const client = ref(matrixClient as never)
+    const selectedRoomId = ref('!room:example.org')
+    const userId = ref('@alice:example.org')
+
+    const { typingLabel } = useRoomTyping({
+      client,
+      selectedRoomId,
+      userId,
+    })
+
+    ;(typingLabel.value === null).should.equal(true)
+
+    bobIsTyping = true
+    handlers[RoomMemberEvent.Typing]?.(null, {
+      roomId: '!room:example.org',
+    })
+
+    String(typingLabel.value).should.equal('Bob is typing…')
+  })
+
+  it('ignores typing events for other rooms', () => {
+    const handlers: Record<string, (event: unknown, member: unknown) => void> =
+      {}
+    const matrixClient = {
+      getRoom: vi.fn(() => mockRoom([])),
+      on: vi.fn((eventName: string, handler: typeof handlers[string]) => {
+        handlers[eventName] = handler
+      }),
+      off: vi.fn(),
+    }
+
+    const client = ref(matrixClient as never)
+    const selectedRoomId = ref('!room:example.org')
+    const userId = ref('@alice:example.org')
+
+    const { typingLabel } = useRoomTyping({
+      client,
+      selectedRoomId,
+      userId,
+    })
+
+    handlers[RoomMemberEvent.Typing]?.(null, {
+      roomId: '!other:example.org',
+    })
+
+    ;(typingLabel.value === null).should.equal(true)
+  })
+})

--- a/tests/unit/utils/composerTypingNotifier.spec.ts
+++ b/tests/unit/utils/composerTypingNotifier.spec.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, it, vi } from 'vitest'
+import {
+  createComposerTypingNotifier,
+  TYPING_IDLE_MS,
+  TYPING_REFRESH_MS,
+  TYPING_SERVER_TIMEOUT_MS,
+} from '~/utils/composerTypingNotifier'
+
+describe('composerTypingNotifier', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends typing true once then false after idle', async () => {
+    const sendTyping = vi.fn(async () => ({}))
+    const notifier = createComposerTypingNotifier({
+      getRoomId: () => '!room:example.org',
+      sendTyping,
+      isEnabled: () => true,
+    })
+
+    notifier.notifyInput()
+    await Promise.resolve()
+
+    sendTyping.mock.calls.length.should.equal(1)
+    sendTyping.mock.calls[0]!.should.deep.equal([
+      '!room:example.org',
+      true,
+      TYPING_SERVER_TIMEOUT_MS,
+    ])
+
+    vi.advanceTimersByTime(TYPING_IDLE_MS)
+    await Promise.resolve()
+
+    const falseCalls = sendTyping.mock.calls.filter(
+      (call) => call[1] === false,
+    )
+    falseCalls.length.should.equal(1)
+    falseCalls[0]!.should.deep.equal([
+      '!room:example.org',
+      false,
+      TYPING_SERVER_TIMEOUT_MS,
+    ])
+  })
+
+  it('refreshes typing true without spamming on each keystroke', async () => {
+    const sendTyping = vi.fn(async () => ({}))
+    const notifier = createComposerTypingNotifier({
+      getRoomId: () => '!room:example.org',
+      sendTyping,
+      isEnabled: () => true,
+    })
+
+    notifier.notifyInput()
+    await Promise.resolve()
+    notifier.notifyInput()
+    notifier.notifyInput()
+    await Promise.resolve()
+
+    sendTyping.mock.calls.length.should.equal(1)
+
+    vi.advanceTimersByTime(TYPING_REFRESH_MS)
+    await Promise.resolve()
+
+    const trueCalls = sendTyping.mock.calls.filter(
+      (call) => call[1] === true,
+    )
+    trueCalls.length.should.equal(2)
+  })
+
+  it('notifyStopped sends false immediately', async () => {
+    const sendTyping = vi.fn(async () => ({}))
+    const notifier = createComposerTypingNotifier({
+      getRoomId: () => '!room:example.org',
+      sendTyping,
+      isEnabled: () => true,
+    })
+
+    notifier.notifyInput()
+    await Promise.resolve()
+    notifier.notifyStopped()
+    await Promise.resolve()
+
+    sendTyping.mock.calls.length.should.equal(2)
+    sendTyping.mock.calls[1]![1].should.equal(false)
+  })
+
+  it('does not send when disabled or room missing', async () => {
+    const sendTyping = vi.fn(async () => ({}))
+    const notifier = createComposerTypingNotifier({
+      getRoomId: () => null,
+      sendTyping,
+      isEnabled: () => true,
+    })
+
+    notifier.notifyInput()
+    await Promise.resolve()
+    sendTyping.mock.calls.length.should.equal(0)
+
+    const disabledNotifier = createComposerTypingNotifier({
+      getRoomId: () => '!room:example.org',
+      sendTyping,
+      isEnabled: () => false,
+    })
+    disabledNotifier.notifyInput()
+    await Promise.resolve()
+    sendTyping.mock.calls.length.should.equal(0)
+  })
+})

--- a/tests/unit/utils/typingIndicator.spec.ts
+++ b/tests/unit/utils/typingIndicator.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it } from 'vitest'
+import {
+  buildTypingIndicatorLabel,
+  getTypingMembers,
+  resolveTypingDisplayName,
+} from '~/utils/typingIndicator'
+
+function mockMember(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: '@alice:example.org',
+    name: 'Alice',
+    typing: true,
+    membership: 'join',
+    ...overrides,
+  }
+}
+
+function mockRoom(members: ReturnType<typeof mockMember>[]) {
+  return { getMembers: () => members }
+}
+
+function translateStub(
+  key: string,
+  placeholders?: Record<string, string>,
+): string {
+  if (key === 'chat.typingOne') {
+    return `${placeholders?.name} is typing…`
+  }
+  if (key === 'chat.typingTwo') {
+    return `${placeholders?.first} and ${placeholders?.second} are typing…`
+  }
+  if (key === 'chat.typingManyOneOther') {
+    return `${placeholders?.first}, ${placeholders?.second} and 1 other are typing…`
+  }
+  if (key === 'chat.typingManyOthers') {
+    return `${placeholders?.first}, ${placeholders?.second} and ${placeholders?.count} others are typing…`
+  }
+  return key
+}
+
+describe('typingIndicator', () => {
+  it('resolves display name from member name or user id', () => {
+    resolveTypingDisplayName(mockMember()).should.equal('Alice')
+    resolveTypingDisplayName(
+      mockMember({ name: undefined }),
+    ).should.equal('@alice:example.org')
+  })
+
+  it('filters typing members excluding self and non-join', () => {
+    const room = mockRoom([
+      mockMember({ userId: '@alice:example.org', typing: true }),
+      mockMember({
+        userId: '@bob:example.org',
+        name: 'Bob',
+        typing: true,
+      }),
+      mockMember({
+        userId: '@self:example.org',
+        typing: true,
+      }),
+      mockMember({
+        userId: '@invite:example.org',
+        typing: true,
+        membership: 'invite',
+      }),
+      mockMember({ userId: '@idle:example.org', typing: false }),
+    ])
+    const members = getTypingMembers(room, '@self:example.org')
+    members.length.should.equal(2)
+    members[0]!.userId!.should.equal('@alice:example.org')
+    members[1]!.userId!.should.equal('@bob:example.org')
+  })
+
+  it('builds labels for one, two, and many typers', () => {
+    const emptyLabel = buildTypingIndicatorLabel([], translateStub)
+    ;(emptyLabel === null).should.equal(true)
+    buildTypingIndicatorLabel(
+      [mockMember()],
+      translateStub,
+    ).should.equal('Alice is typing…')
+    buildTypingIndicatorLabel(
+      [
+        mockMember({ name: 'Alice' }),
+        mockMember({
+          userId: '@bob:example.org',
+          name: 'Bob',
+        }),
+      ],
+      translateStub,
+    ).should.equal('Alice and Bob are typing…')
+    buildTypingIndicatorLabel(
+      [
+        mockMember({ name: 'Alice' }),
+        mockMember({
+          userId: '@bob:example.org',
+          name: 'Bob',
+        }),
+        mockMember({
+          userId: '@carol:example.org',
+          name: 'Carol',
+        }),
+      ],
+      translateStub,
+    ).should.equal('Alice, Bob and 1 other are typing…')
+    buildTypingIndicatorLabel(
+      [
+        mockMember({ name: 'Alice' }),
+        mockMember({
+          userId: '@bob:example.org',
+          name: 'Bob',
+        }),
+        mockMember({
+          userId: '@carol:example.org',
+          name: 'Carol',
+        }),
+        mockMember({
+          userId: '@dave:example.org',
+          name: 'Dave',
+        }),
+      ],
+      translateStub,
+    ).should.equal('Alice, Bob and 2 others are typing…')
+  })
+})


### PR DESCRIPTION
- Added typing indicators in the active room, displaying `m.typing` events via the SDK.
- Implemented debounced outbound `sendTyping` functionality from the message composer.
- Introduced a compact label above the message input for typing notifications in both English and German.
- Enhanced internationalization support in `useAppI18n` for new typing-related messages.
- Updated `ChatTypingIndicator` component to show typing status of multiple users.
- Added unit and E2E tests to verify the functionality of typing indicators.
- Updated CHANGELOG to reflect the new typing indicator features.