### PR TITLE
Implement matrix space creation from UI and enhance related features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Matrix space creation from the UI: `/spaces/new` form, space-rail entry,
+  `createMatrixSpace` API wiring, navigation to the new space in chat,
+  and subspace create via `/rooms/new?kind=space` (#22)
 - Voice message recording in chat: microphone capture, preview, upload,
   Matrix `m.audio` send with MSC3245 voice marker, timeline playback, and
   reply/thread support for voice sends (#27)

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -1792,7 +1792,7 @@ function toggleSpaceRail() {
   spaceRailExpanded.value = !spaceRailExpanded.value;
 }
 
-function openCreateSpaceStub() {
+function openCreateSpace() {
   navigateTo("/spaces/new");
 }
 
@@ -2150,7 +2150,7 @@ watch(
           :expanded="spaceRailExpanded"
           @select-space="selectSpace"
           @toggle-expanded="toggleSpaceRail"
-          @create-space="openCreateSpaceStub"
+          @create-space="openCreateSpace"
         />
         <ChatRoomCategoryList
           :selected-space-name="selectedSpaceName"

--- a/tests/e2e/features/chat.feature
+++ b/tests/e2e/features/chat.feature
@@ -15,6 +15,12 @@ Feature: Chat
     When I open the space settings page for "space-demo"
     Then I am redirected to the root page
 
+  Scenario: Create space from rail appears in navigation
+    When I open the login page
+    And I sign in with configured credentials
+    And I create a new space with a unique name
+    Then I should see that space in the space rail
+
   Scenario: Reload on chat with valid session keeps chat
     When I open the login page
     And I sign in with configured credentials

--- a/tests/e2e/step-definitions/chat.steps.mjs
+++ b/tests/e2e/step-definitions/chat.steps.mjs
@@ -623,3 +623,31 @@ Then('I should see voice recording permission denied feedback', async function (
   await expect(this.page.getByTestId('voice-recorder-error').last())
     .toContainText(/Microphone access was denied|Mikrofonzugriff verweigert/i)
 })
+
+When('I create a new space with a unique name', async function () {
+  const uniqueName = `E2E_CREATE_SPACE_${Date.now()}`
+  this.lastCreatedSpaceName = uniqueName
+  await this.page.goto(`${BASE_URL}/chat`)
+  await expect(this.page).toHaveURL(/\/chat/, { timeout: 15000 })
+  const createSpaceButton = this.page.getByRole('button', {
+    name: /Create space|Space erstellen/i,
+  })
+  await expect(createSpaceButton).toBeVisible({ timeout: 15000 })
+  await createSpaceButton.click()
+  await expect(this.page).toHaveURL(/\/spaces\/new/, { timeout: 15000 })
+  await this.page.getByLabel(/Space name|Space-Name/i).fill(uniqueName)
+  await this.page.getByRole('button', {
+    name: /Create space|Space erstellen/i,
+  }).click()
+  await expect(this.page).toHaveURL(/\/chat/, { timeout: 30000 })
+})
+
+Then('I should see that space in the space rail', async function () {
+  const spaceName = this.lastCreatedSpaceName
+  if (!spaceName) {
+    throw new Error('Missing lastCreatedSpaceName from previous step')
+  }
+  await expect(
+    this.page.getByRole('button', { name: spaceName }),
+  ).toBeVisible({ timeout: 30000 })
+})

--- a/tests/unit/composables/useMatrixClient.spec.ts
+++ b/tests/unit/composables/useMatrixClient.spec.ts
@@ -1372,6 +1372,208 @@ describe('normalizeMatrixUserId / matrix.to helpers', () => {
   })
 })
 
+describe('createMatrixSpace', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.clear()
+    }
+    vi.clearAllMocks()
+  })
+
+  async function loginForSpaceCreate(
+    createRoomImpl?: () => Promise<{ room_id: string }>,
+  ) {
+    const createRoom = vi.fn(
+      createRoomImpl ??
+        (async () => ({ room_id: '!new-space:example.org' })),
+    )
+    const matrixClient = {
+      getUserId: () => '@alice:example.org',
+      createRoom,
+      startClient: vi.fn(),
+      initRustCrypto: vi.fn(async () => undefined),
+      getCrypto: () => null,
+      getDeviceId: () => 'DEV',
+    }
+    const authClient = {
+      loginRequest: vi.fn(async () => ({
+        access_token: 't',
+        user_id: '@alice:example.org',
+        device_id: 'DEV',
+      })),
+    }
+    createClient
+      .mockReturnValueOnce(authClient)
+      .mockReturnValueOnce(matrixClient)
+
+    const { useMatrixClient } = await import('~/composables/useMatrixClient')
+    const clientApi = useMatrixClient()
+    await clientApi.login('https://example.org', 'alice', 'pw')
+    return { clientApi, createRoom }
+  }
+
+  it('creates a private space with m.space creation content', async () => {
+    const { clientApi, createRoom } = await loginForSpaceCreate()
+    const spaceId = await clientApi.createMatrixSpace({
+      name: 'Team Space',
+      visibility: 'private',
+    })
+
+    expect(spaceId).toBe('!new-space:example.org')
+    expect(createRoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Team Space',
+        visibility: 'private',
+        creation_content: { type: 'm.space' },
+      }),
+    )
+    const initialState = createRoom.mock.calls[0][0].initial_state
+    expect(initialState).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'm.room.join_rules',
+          content: { join_rule: 'invite' },
+        }),
+        expect.objectContaining({
+          type: 'm.room.history_visibility',
+          content: { history_visibility: 'invited' },
+        }),
+      ]),
+    )
+    expect(
+      initialState.some(
+        (event: { type: string }) => event.type === 'm.room.encryption',
+      ),
+    ).toBe(false)
+  })
+
+  it('creates a public space with topic', async () => {
+    const { clientApi, createRoom } = await loginForSpaceCreate()
+    await clientApi.createMatrixSpace({
+      name: 'Open Space',
+      topic: 'Welcome',
+      visibility: 'public',
+    })
+
+    expect(createRoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Open Space',
+        topic: 'Welcome',
+        visibility: 'public',
+      }),
+    )
+    const initialState = createRoom.mock.calls[0][0].initial_state
+    expect(initialState).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'm.room.join_rules',
+          content: { join_rule: 'public' },
+        }),
+        expect.objectContaining({
+          type: 'm.room.history_visibility',
+          content: { history_visibility: 'world_readable' },
+        }),
+      ]),
+    )
+  })
+
+  it('rejects empty space name before createRoom', async () => {
+    const { clientApi, createRoom } = await loginForSpaceCreate()
+
+    await expect(
+      clientApi.createMatrixSpace({ name: '   ', visibility: 'private' }),
+    ).rejects.toThrow('Space name is required')
+    expect(createRoom).not.toHaveBeenCalled()
+  })
+
+  it('filters self from invite list', async () => {
+    const { clientApi, createRoom } = await loginForSpaceCreate()
+    await clientApi.createMatrixSpace({
+      name: 'Invited Space',
+      visibility: 'private',
+      inviteUserIds: [
+        '@alice:example.org',
+        '@bob:example.org',
+      ],
+    })
+
+    expect(createRoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invite: ['@bob:example.org'],
+      }),
+    )
+  })
+
+  it('maps transport failures to connection hint', async () => {
+    const { clientApi } = await loginForSpaceCreate(async () => {
+      throw new TypeError('Failed to fetch')
+    })
+    const { HOMESERVER_CONNECTION_HINT_ERROR } =
+      await import('~/composables/useMatrixClient')
+
+    await expect(
+      clientApi.createMatrixSpace({
+        name: 'Fail Space',
+        visibility: 'private',
+      }),
+    ).rejects.toThrow(HOMESERVER_CONNECTION_HINT_ERROR)
+  })
+
+  it('maps matrix errors to create space message', async () => {
+    const matrixError = {
+      data: { errcode: 'M_CONFLICT' },
+    }
+    const { clientApi } = await loginForSpaceCreate(async () => {
+      throw matrixError
+    })
+
+    await expect(
+      clientApi.createMatrixSpace({
+        name: 'Fail Space',
+        visibility: 'private',
+      }),
+    ).rejects.toThrow('Could not create space')
+  })
+
+  it('links new space to parent when parentSpaceId is set', async () => {
+    const { clientApi, createRoom } = await loginForSpaceCreate()
+    const spaceStateHelpers = await import(
+      '~/composables/matrix/spaceStateHelpers'
+    )
+    const waitForParent = await import('~/utils/waitForRoomSpaceParent')
+    const moveMock = vi
+      .spyOn(spaceStateHelpers, 'moveRoomBetweenParents')
+      .mockResolvedValue(undefined)
+    const waitMock = vi
+      .spyOn(waitForParent, 'waitForRoomSpaceParentLink')
+      .mockResolvedValue(undefined)
+    await clientApi.createMatrixSpace({
+      name: 'Child Space',
+      visibility: 'private',
+      parentSpaceId: '!parent:example.org',
+      insertIndex: 2,
+    })
+
+    expect(createRoom).toHaveBeenCalled()
+    expect(moveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: '!new-space:example.org',
+        previousParentSpaceId: null,
+        nextParentSpaceId: '!parent:example.org',
+        insertIndex: 2,
+      }),
+    )
+    expect(waitMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '!new-space:example.org',
+      '!parent:example.org',
+    )
+    moveMock.mockRestore()
+    waitMock.mockRestore()
+  })
+})
+
 describe('getOrCreateDirectMessageRoom', () => {
   it('reuses joined room from m.direct map', async () => {
     const createRoom = vi.fn()

--- a/tests/unit/pages/rooms-new.spec.ts
+++ b/tests/unit/pages/rooms-new.spec.ts
@@ -5,6 +5,7 @@ import RoomsNewPage from '~/pages/rooms/new.vue'
 
 const navigateToMock = vi.fn(async () => undefined)
 const createGroupRoomMock = vi.fn(async () => '!created:example.org')
+const createMatrixSpaceMock = vi.fn(async () => '!created-subspace:example.org')
 const searchUsersDirectoryMock = vi.fn(async () => [])
 
 vi.mock('~/composables/useAppI18n', () => {
@@ -20,7 +21,7 @@ vi.mock('~/composables/useMatrixClient', () => {
     useMatrixClient: () => ({
       userId: ref('@self:example.org'),
       createGroupRoom: createGroupRoomMock,
-      createMatrixSpace: vi.fn(),
+      createMatrixSpace: createMatrixSpaceMock,
       searchUsersDirectory: searchUsersDirectoryMock,
     }),
   }
@@ -127,5 +128,51 @@ describe('rooms/new page', () => {
         inviteUserIds: ['@guest:example.org'],
       }),
     )
+  })
+
+  it('creates subspace and navigates with room and root query', async () => {
+    vi.stubGlobal('useRoute', () => ({
+      query: {
+        kind: 'space',
+        parent: '!parent:example.org',
+        root: '!parent:example.org',
+      },
+    }))
+    const wrapper = mount(RoomsNewPage, {
+      global: {
+        stubs: {
+          UCard: UCardStub,
+          UFormField: UFormFieldStub,
+          UInput: UInputStub,
+          UTextarea: UTextareaStub,
+          UAlert: UAlertStub,
+          UButton: UButtonStub,
+        },
+      },
+    })
+    const inputs = wrapper.findAll('input')
+    await inputs[0].setValue('Nested Space')
+    const submitButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'rooms.createSpaceSubmit')
+    expect(submitButton).toBeDefined()
+    await submitButton!.trigger('click')
+    await Promise.resolve()
+
+    expect(createMatrixSpaceMock).toHaveBeenCalledWith({
+      name: 'Nested Space',
+      topic: '',
+      visibility: 'private',
+      parentSpaceId: '!parent:example.org',
+    })
+    expect(createGroupRoomMock).not.toHaveBeenCalled()
+    expect(navigateToMock).toHaveBeenCalledWith({
+      path: '/chat',
+      query: {
+        room: '!created-subspace:example.org',
+        root: '!parent:example.org',
+      },
+    })
+    vi.stubGlobal('useRoute', () => ({ query: {} }))
   })
 })

--- a/tests/unit/pages/spaces-new.spec.ts
+++ b/tests/unit/pages/spaces-new.spec.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import SpacesNewPage from '~/pages/spaces/new.vue'
+
+const navigateToMock = vi.fn(async () => undefined)
+const createMatrixSpaceMock = vi.fn(async () => '!created-space:example.org')
+
+vi.mock('~/composables/useAppI18n', () => {
+  return {
+    useAppI18n: () => ({
+      translateText: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('~/composables/useMatrixClient', () => {
+  return {
+    useMatrixClient: () => ({
+      createMatrixSpace: createMatrixSpaceMock,
+    }),
+  }
+})
+
+vi.stubGlobal('navigateTo', navigateToMock)
+
+const UCardStub = {
+  template: '<div><slot name="header" /><slot /><slot name="footer" /></div>',
+}
+const UFormFieldStub = { template: '<div><slot /></div>' }
+const UInputStub = {
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  template: `
+    <input
+      :value="modelValue"
+      @input="$emit('update:modelValue', $event.target.value)"
+    >
+  `,
+}
+const UAlertStub = { props: ['title'], template: '<p>{{ title }}</p>' }
+const UButtonStub = {
+  props: ['to', 'disabled', 'loading'],
+  template: '<button :disabled="disabled"><slot /></button>',
+}
+
+describe('spaces/new page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createMatrixSpaceMock.mockResolvedValue('!created-space:example.org')
+    ;(globalThis as Record<string, unknown>).ref = ref
+  })
+
+  function mountPage() {
+    return mount(SpacesNewPage, {
+      global: {
+        stubs: {
+          UCard: UCardStub,
+          UFormField: UFormFieldStub,
+          UInput: UInputStub,
+          UAlert: UAlertStub,
+          UButton: UButtonStub,
+        },
+      },
+    })
+  }
+
+  it('creates space and navigates to chat with space query', async () => {
+    const wrapper = mountPage()
+    const nameInput = wrapper.find('input')
+    await nameInput.setValue('My Space')
+    const submitButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'spaces.createSubmit')
+    expect(submitButton).toBeDefined()
+    await submitButton!.trigger('click')
+    await Promise.resolve()
+
+    expect(createMatrixSpaceMock).toHaveBeenCalledWith({
+      name: 'My Space',
+      topic: '',
+      visibility: 'private',
+    })
+    expect(navigateToMock).toHaveBeenCalledWith({
+      path: '/chat',
+      query: { space: '!created-space:example.org' },
+    })
+  })
+
+  it('disables submit when space name is empty', () => {
+    const wrapper = mountPage()
+    const submitButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'spaces.createSubmit')
+    expect(submitButton?.attributes('disabled')).toBeDefined()
+  })
+
+  it('shows error message when createMatrixSpace fails', async () => {
+    createMatrixSpaceMock.mockRejectedValueOnce(
+      new Error('Could not create space'),
+    )
+    const wrapper = mountPage()
+    const nameInput = wrapper.find('input')
+    await nameInput.setValue('Broken Space')
+    const submitButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'spaces.createSubmit')
+    await submitButton!.trigger('click')
+    await Promise.resolve()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Could not create space')
+  })
+})


### PR DESCRIPTION
- Added functionality for creating matrix spaces directly from the UI, including a new `/spaces/new` form and navigation to the newly created space in chat.
- Integrated `createMatrixSpace` API for seamless space creation and subspace management via `/rooms/new?kind=space`.
- Updated the chat interface to reflect the new space creation capabilities and added corresponding E2E tests to verify functionality.
- Enhanced the CHANGELOG to document these new features and improvements.