### PR TITLE
Enhance build process and documentation for chunk sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Build docs and Vite `manualChunks` for `matrix-js-sdk` and
+  `@matrix-org/matrix-sdk-crypto-wasm`; `npm run build:chunks` lists
+  client chunk sizes after production build ([#62](https://github.com/mjkatgithub/Decentra/issues/62))
 - Mention-priority unread: red channel/space/thread indicators from
   Matrix highlight counts, space-rail rollup with unread counts
   (Discord-style badges), tab title prefix, and optional browser

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ npm run build
 npm run preview
 ```
 
+Production bundles are larger than dev because of `matrix-js-sdk`
+(~1 MB+ minified). Vite may warn about chunks &gt; 500 kB — that is
+normal for Matrix clients. See [docs/build-bundling.md](docs/build-bundling.md)
+for chunk splitting, baseline sizes, and `npm run build:chunks`.
+
 ## Tests
 
 ```bash

--- a/docs/build-bundling.md
+++ b/docs/build-bundling.md
@@ -1,0 +1,108 @@
+# Build bundling and chunk sizes
+
+Decentra is a Matrix web client; `matrix-js-sdk` and Rust crypto WASM
+dominate the production bundle. This document explains what to expect
+from `npm run build`, how chunks are split, and why dev can feel slower
+than preview/production.
+
+## Dev vs production
+
+| Mode | Command | Notes |
+|------|---------|--------|
+| Development | `npm run dev` | Unminified modules, HMR, no aggressive chunking — larger and more requests. |
+| Production | `npm run build` + `npm run preview` | Minified, tree-shaken, manual vendor chunks — closer to deploy/GitHub Pages. |
+| Static export | `npm run generate` | Same client bundle as `build` for static hosting. |
+
+Production often feels smoother than dev even when total JS bytes are
+similar, because the browser loads fewer, optimized files.
+
+## Vite “chunks larger than 500 kB” warning
+
+After `npm run build`, Vite may warn that some chunks exceed 500 kB.
+For Matrix clients this is **expected**: `matrix-js-sdk` alone is on the
+order of **~1 MB minified** (before gzip). Splitting into dedicated chunks
+does **not** reduce how much JS the app must download on first load; it
+improves **cacheability** (app code can redeploy without invalidating the
+SDK chunk) and makes bundle inspection clearer.
+
+Configuration lives in [`nuxt.config.ts`](../nuxt.config.ts):
+
+- `matrix-js-sdk` → chunk `matrix-js-sdk`
+- `@matrix-org/matrix-sdk-crypto-wasm` → chunk `matrix-crypto-wasm`
+
+Output file names are still content-hashed (e.g. `uwvG9rjQ.js`); use
+`npm run build:chunks` or the build log to inspect sizes.
+
+## Measured baseline (issue #62)
+
+Recorded on Windows, Nuxt 4.3.1, `matrix-js-sdk` ^37.5.0.
+
+### Before `manualChunks`
+
+| Asset (build log) | Minified | Gzip (Vite) |
+|-------------------|----------|-------------|
+| Single largest JS (`D2bpsiS2.js`) | **1,476 kB** | 420 kB |
+| Next largest (`Ch2C0R-s.js`) | 259 kB | 71 kB |
+| `matrix_sdk_crypto_wasm_bg.*.wasm` | 5,399 kB | 1,796 kB |
+
+Vite warned about chunks &gt; 500 kB (the ~1.5 MB bundle).
+
+### After `manualChunks`
+
+| Role (logical chunk) | Minified (build log) | Gzip (Vite) |
+|----------------------|----------------------|-------------|
+| `matrix-js-sdk` (hashed `uwvG9rjQ.js`) | **957 kB** | 263 kB |
+| `matrix-crypto-wasm` + related (`CUKWLU_I.js`) | **479 kB** | 157 kB |
+| App / other vendors (`BOt9W6Ew.js`, etc.) | ≤ 259 kB each | — |
+| WASM (unchanged) | 5,399 kB | 1,796 kB |
+
+**First-load JS total** (all `.js` under `.output/public/_nuxt`): ~1,955 kB
+before and after — **no meaningful byte reduction**, but the Matrix SDK
+is no longer merged into one anonymous megachunk. Two chunks still exceed
+500 kB (SDK + crypto path); that is acceptable for this stack.
+
+### Route-level code splitting
+
+Nuxt already emits per-route chunks (e.g. `chat`). `useMatrixClient()` is
+used from [`app/app.vue`](../app/app.vue) and auth middleware, so
+`matrix-js-sdk` still loads on the landing page for session restore.
+Deferring the SDK to `/chat` only would be a **runtime** change (see
+issue #103), not bundling alone.
+
+## Icons (no runtime CDN fetch)
+
+`@iconify-json/lucide` is a **devDependency** bundled locally. Nuxt Icon
+uses `serverBundleMode: local` so Lucide icons are not fetched from
+Iconify CDN at runtime.
+
+## How to reproduce measurements
+
+```bash
+npm run build
+npm run build:chunks
+```
+
+Optional treemap:
+
+```bash
+npx nuxi analyze
+```
+
+For Network-tab first load: `npm run preview`, open DevTools → Network,
+disable cache, load `/`, `/login`, and `/chat` (logged in). Compare
+request count and transferred JS; expect similar totals, separate SDK
+files after splitting.
+
+## Known build warnings (follow-up)
+
+Non-fatal noise during `npm run build` (Tailwind sourcemap plugin message,
+Node `DEP0155` from transitive `@iconify` / `@vueuse` exports) is tracked in
+[#120](https://github.com/mjkatgithub/Decentra/issues/120). They do not fail
+the build and are unrelated to Matrix chunk sizes.
+
+## Related issues
+
+- [#62](https://github.com/mjkatgithub/Decentra/issues/62) — this bundling work
+- [#120](https://github.com/mjkatgithub/Decentra/issues/120) — build warning cleanup
+- [#63](https://github.com/mjkatgithub/Decentra/issues/63) — source file size limits
+- [#103](https://github.com/mjkatgithub/Decentra/issues/103) — chat runtime performance

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -46,6 +46,20 @@ export default defineNuxtConfig({
   vite: {
     optimizeDeps: {
       exclude: ['@matrix-org/matrix-sdk-crypto-wasm']
+    },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('@matrix-org/matrix-sdk-crypto-wasm')) {
+              return 'matrix-crypto-wasm'
+            }
+            if (id.includes('matrix-js-sdk')) {
+              return 'matrix-js-sdk'
+            }
+          }
+        }
+      }
     }
   },
   colorMode: {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
+    "build:chunks": "node scripts/print-nuxt-chunk-sizes.mjs",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",

--- a/scripts/print-nuxt-chunk-sizes.mjs
+++ b/scripts/print-nuxt-chunk-sizes.mjs
@@ -1,0 +1,47 @@
+/**
+ * Lists minified JS chunk sizes under .output/public/_nuxt after `npm run build`.
+ */
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const chunkDir = join(process.cwd(), '.output', 'public', '_nuxt')
+
+function formatKiB(bytes) {
+  return `${(bytes / 1024).toFixed(1)} kB`
+}
+
+async function main() {
+  let entries
+  try {
+    entries = await readdir(chunkDir)
+  } catch {
+    console.error(
+      'Missing .output/public/_nuxt — run `npm run build` first.',
+    )
+    process.exit(1)
+  }
+
+  const jsFiles = entries.filter((name) => name.endsWith('.js'))
+  const sizes = await Promise.all(
+    jsFiles.map(async (name) => {
+      const filePath = join(chunkDir, name)
+      const fileStat = await stat(filePath)
+      return { name, bytes: fileStat.size }
+    }),
+  )
+
+  sizes.sort((left, right) => right.bytes - left.bytes)
+
+  console.log('Nuxt client chunks (.output/public/_nuxt/*.js):\n')
+  for (const { name, bytes } of sizes) {
+    console.log(`  ${formatKiB(bytes).padStart(12)}  ${name}`)
+  }
+
+  const totalBytes = sizes.reduce((sum, entry) => sum + entry.bytes, 0)
+  console.log(`\n  ${formatKiB(totalBytes).padStart(12)}  total (${sizes.length} files)`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
- Implemented manual chunking for `matrix-js-sdk` and `@matrix-org/matrix-sdk-crypto-wasm` in Vite configuration to improve production bundle organization.
- Added a new script `build:chunks` to list minified JS chunk sizes after the production build, aiding in performance monitoring.
- Updated `CHANGELOG` to document these enhancements and added a new section in `README.md` explaining production bundle sizes and chunk splitting.
- Created `build-bundling.md` to provide detailed insights on build processes, chunk sizes, and expected warnings during production builds.