### PR TITLE
Update E2E testing for mobile interactions and enhance context manage…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- E2E mobile reply: scope Playwright `hasTouch` to `@mobile` browser
+  contexts only so tap-to-reply works without breaking desktop hover
+  actions; re-enable `Reply via tap on mobile viewport` scenario
+  ([#135](https://github.com/mjkatgithub/Decentra/issues/135))
+
 - Synapse E2E on Linux CI: restore data-dir ownership after `synapse generate`
   so `homeserver.yaml` overrides are writable (GitHub Actions EACCES)
   ([#122](https://github.com/mjkatgithub/Decentra/issues/122))

--- a/tests/e2e/features/chat.feature
+++ b/tests/e2e/features/chat.feature
@@ -157,7 +157,7 @@ Feature: Chat
     And I click reply on message body "E2E_SEED_BASE_MESSAGE"
     Then I should see the reply composer with preview "E2E_SEED_BASE_MESSAGE"
 
-  @wip
+  @mobile
   Scenario: Reply via tap on mobile viewport
     When I open the login page
     And I sign in with configured credentials

--- a/tests/e2e/support/hooks.mjs
+++ b/tests/e2e/support/hooks.mjs
@@ -6,6 +6,7 @@ import { loadE2EEnv } from '../scripts/runtime-e2e-env.mjs'
 setDefaultTimeout(120 * 1000)
 
 let browser
+let context
 let page
 
 const isHeadless = process.env.HEADLESS !== 'false'
@@ -34,6 +35,13 @@ function shouldValidateSynapseEnv(pickle) {
       step.text.includes(marker),
     )
   })
+}
+
+function scenarioNeedsTouchContext(pickle) {
+  if (!pickle?.tags) {
+    return false
+  }
+  return pickle.tags.some((tag) => tag.name === '@mobile')
 }
 
 function validateSynapseEnv() {
@@ -65,10 +73,21 @@ Before(async function ({ pickle }) {
   if (shouldValidateSynapseEnv(pickle)) {
     validateSynapseEnv()
   }
-  page = await browser.newPage()
+  const touchContext = scenarioNeedsTouchContext(pickle)
+  context = await browser.newContext(
+    touchContext ? { hasTouch: true } : {},
+  )
+  page = await context.newPage()
   this.page = page
 })
 
 After(async function () {
-  if (page) await page.close()
+  if (page) {
+    await page.close()
+    page = undefined
+  }
+  if (context) {
+    await context.close()
+    context = undefined
+  }
 })


### PR DESCRIPTION
…ment

- Scoped Playwright's `hasTouch` capability to `@mobile` browser contexts, ensuring tap-to-reply functionality works seamlessly without interfering with desktop hover actions.
- Re-enabled the `Reply via tap on mobile viewport` scenario in E2E tests to validate mobile interactions.
- Improved context management in E2E hooks to handle touch contexts more effectively, enhancing overall test reliability.
- Updated CHANGELOG to document these changes and their impact on mobile testing scenarios.