### PR TITLE
Update CHANGELOG and enhance chat space functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,8 +295,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Space home panel: include `m.space.child`-linked channels in
-  `visibleRooms` so lobby channel selection keeps `selectedRoomId` and
-  hides the panel; re-enable cluster C E2E (`@space_home`, space leave)
+  `visibleRooms`; keep lobby channel selection when sidebar filter lags;
+  scope space-home E2E click to the panel; re-enable cluster C E2E
   ([#136](https://github.com/mjkatgithub/Decentra/issues/136))
 
 - E2E mobile reply: scope Playwright `hasTouch` to `@mobile` browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,7 +296,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Space home panel: include `m.space.child`-linked channels in
   `visibleRooms`; keep lobby channel selection when sidebar filter lags;
-  scope space-home E2E click to the panel; re-enable cluster C E2E
+  scope space-home E2E click to the panel; isolate `@space_home` with a
+  dedicated seeded space channel so the leave-channel scenario no longer
+  empties the shared channel; re-enable cluster C E2E
   ([#136](https://github.com/mjkatgithub/Decentra/issues/136))
 
 - E2E mobile reply: scope Playwright `hasTouch` to `@mobile` browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Space home panel: include `m.space.child`-linked channels in
+  `visibleRooms` so lobby channel selection keeps `selectedRoomId` and
+  hides the panel; re-enable cluster C E2E (`@space_home`, space leave)
+  ([#136](https://github.com/mjkatgithub/Decentra/issues/136))
+
 - E2E mobile reply: scope Playwright `hasTouch` to `@mobile` browser
   contexts only so tap-to-reply works without breaking desktop hover
   actions; re-enable `Reply via tap on mobile viewport` scenario

--- a/app/composables/chat/useChatSpaceRail.ts
+++ b/app/composables/chat/useChatSpaceRail.ts
@@ -127,7 +127,13 @@ export function useChatSpaceRail(options: {
 
     return roomItems.value.filter((room) => {
       if (room.parentSpaceIds.length === 0) {
-        return activeSpaceId === HOME_SPACE_ID;
+        return isRoomListedUnderSpaceSubtree(
+          room.roomId,
+          activeSpaceId,
+          roomsById,
+          getRoomType,
+          roomDisplayName,
+        );
       }
       if (
         isRoomUnderAncestorSpace({

--- a/app/composables/chat/useChatSpaceRail.ts
+++ b/app/composables/chat/useChatSpaceRail.ts
@@ -39,6 +39,7 @@ export function useChatSpaceRail(options: {
   allMessages: Ref<unknown[]>;
   messages: Ref<unknown[]>;
   suppressAutoRoomSelect?: Ref<boolean>;
+  spaceLobbyRoomIds?: Ref<ReadonlySet<string>>;
 }) {
   const joinedSpaceIds = computed(() =>
     getJoinedSpaceRoomIds(
@@ -276,6 +277,10 @@ export function useChatSpaceRail(options: {
           (room) => room.roomId === activeRoomId,
         );
         if (!selectedExists) {
+          const lobbyRoomIds = options.spaceLobbyRoomIds?.value;
+          if (lobbyRoomIds?.has(activeRoomId)) {
+            return;
+          }
           options.selectedRoomId.value = null;
           options.allMessages.value = [];
           options.messages.value = [];

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -76,6 +76,7 @@ const selectedSpaceId = useState<string | null>(
 );
 const pendingRootSpaceId = ref<string | null>(null);
 const suppressAutoRoomSelect = ref(false);
+const lobbyRoomIdsForActiveSpace = ref<ReadonlySet<string>>(new Set());
 const lobbyJoiningRoomId = ref<string | null>(null);
 const matrixRooms = ref<Array<Record<string, any>>>([]);
 const spaceUnreadForRail = shallowRef<
@@ -164,6 +165,7 @@ const spaceRail = useChatSpaceRail({
   allMessages,
   messages,
   suppressAutoRoomSelect,
+  spaceLobbyRoomIds: lobbyRoomIdsForActiveSpace,
 });
 
 const {
@@ -491,6 +493,16 @@ const spaceLobbyCategories = computed<RoomCategoryGroup[]>(() => {
     return lobbyHierarchyCategories.value;
   }
   return buildSpaceLobbySections();
+});
+
+watchEffect(() => {
+  const lobbyRoomIds = new Set<string>();
+  for (const category of spaceLobbyCategories.value) {
+    for (const room of category.rooms) {
+      lobbyRoomIds.add(room.roomId);
+    }
+  }
+  lobbyRoomIdsForActiveSpace.value = lobbyRoomIds;
 });
 
 const roomCategoryStructure = computed<RoomCategoryGroup[]>(() => {

--- a/tests/e2e/features/chat.feature
+++ b/tests/e2e/features/chat.feature
@@ -358,7 +358,7 @@ Feature: Chat
     And I sign in with configured credentials
     And I select the seeded test space in the space rail
     Then I should see the space home panel
-    When I open the seeded test space channel
+    When I open the seeded space home channel
     Then I should not see the space home panel
 
   @leave_room @wip

--- a/tests/e2e/features/chat.feature
+++ b/tests/e2e/features/chat.feature
@@ -340,7 +340,7 @@ Feature: Chat
     When I reload the current page
     Then the side seeded test room should not appear in the sidebar
 
-  @leave_room @wip
+  @leave_room
   Scenario: Leave seeded space channel from sidebar
     When I open the login page
     And I sign in with configured credentials
@@ -352,7 +352,7 @@ Feature: Chat
     Then I should see the space home panel
     And the seeded test space channel should not appear in the sidebar
 
-  @space_home @wip
+  @space_home
   Scenario: Select space from rail shows overview and opens channel from list
     When I open the login page
     And I sign in with configured credentials

--- a/tests/e2e/scripts/runtime-seed-synapse.mjs
+++ b/tests/e2e/scripts/runtime-seed-synapse.mjs
@@ -295,6 +295,26 @@ async function uploadAudio(accessToken) {
   return body.content_uri
 }
 
+async function createSpaceChannel(accessToken, spaceId, channelName, via, order) {
+  const channelResponse = await withAuth(
+    accessToken,
+    '/_matrix/client/v3/createRoom',
+    { method: 'POST', body: JSON.stringify({ name: channelName }) },
+  )
+  const channelId = channelResponse.room_id
+  await withAuth(
+    accessToken,
+    `/_matrix/client/v3/rooms/${encodeURIComponent(spaceId)}/state/m.space.child/${encodeURIComponent(channelId)}`,
+    { method: 'PUT', body: JSON.stringify({ via, order }) },
+  )
+  await withAuth(
+    accessToken,
+    `/_matrix/client/v3/rooms/${encodeURIComponent(channelId)}/state/m.space.parent/${encodeURIComponent(spaceId)}`,
+    { method: 'PUT', body: JSON.stringify({ via }) },
+  )
+  return channelId
+}
+
 async function main() {
   logStep(`starting seed against ${homeserver}`)
   const primarySession = await ensureUser(primaryLocalpart, primaryPassword)
@@ -328,6 +348,8 @@ async function main() {
   const spaceName = process.env.E2E_TEST_SPACE_NAME || 'Decentra E2E Space'
   const spaceChannelName =
     process.env.E2E_TEST_SPACE_CHANNEL_NAME || 'E2E Space General'
+  const spaceHomeChannelName =
+    process.env.E2E_SPACE_HOME_CHANNEL_NAME || 'E2E Space Home Channel'
   const spaceResponse = await withAuth(
     primarySession.access_token,
     '/_matrix/client/v3/createRoom',
@@ -340,34 +362,23 @@ async function main() {
     },
   )
   const spaceId = spaceResponse.room_id
-  const spaceChannelResponse = await withAuth(
-    primarySession.access_token,
-    '/_matrix/client/v3/createRoom',
-    {
-      method: 'POST',
-      body: JSON.stringify({ name: spaceChannelName }),
-    },
-  )
-  const spaceChannelId = spaceChannelResponse.room_id
   const serverName = new URL(homeserver).hostname
   const via = [serverName]
-  await withAuth(
+  const spaceChannelId = await createSpaceChannel(
     primarySession.access_token,
-    `/_matrix/client/v3/rooms/${encodeURIComponent(spaceId)}/state/m.space.child/${encodeURIComponent(spaceChannelId)}`,
-    {
-      method: 'PUT',
-      body: JSON.stringify({ via, order: 'general' }),
-    },
+    spaceId,
+    spaceChannelName,
+    via,
+    'general',
   )
-  await withAuth(
+  const spaceHomeChannelId = await createSpaceChannel(
     primarySession.access_token,
-    `/_matrix/client/v3/rooms/${encodeURIComponent(spaceChannelId)}/state/m.space.parent/${encodeURIComponent(spaceId)}`,
-    {
-      method: 'PUT',
-      body: JSON.stringify({ via }),
-    },
+    spaceId,
+    spaceHomeChannelName,
+    via,
+    'home',
   )
-  logStep('space + channel created and linked')
+  logStep('space + channels created and linked')
 
   await withAuth(
     secondarySession.access_token,
@@ -522,6 +533,8 @@ async function main() {
     `E2E_TEST_SPACE_ID=${spaceId}`,
     `E2E_TEST_SPACE_CHANNEL_NAME=${spaceChannelName}`,
     `E2E_TEST_SPACE_CHANNEL_ID=${spaceChannelId}`,
+    `E2E_SPACE_HOME_CHANNEL_NAME=${spaceHomeChannelName}`,
+    `E2E_SPACE_HOME_CHANNEL_ID=${spaceHomeChannelId}`,
     `E2E_LEAVE_DM_ROOM_ID=${leaveDmRoomId}`,
   ].join('\n')
   writeFileSync(generatedEnvPath, `${generatedEnv}\n`, 'utf8')

--- a/tests/e2e/step-definitions/leave-room.steps.mjs
+++ b/tests/e2e/step-definitions/leave-room.steps.mjs
@@ -114,15 +114,10 @@ When('I select the seeded test space in the space rail', async function () {
 
 When('I open the seeded test space channel', async function () {
   const channelId = requireEnv('E2E_TEST_SPACE_CHANNEL_ID')
-  const channelName =
-    process.env.E2E_TEST_SPACE_CHANNEL_NAME || 'E2E Space General'
-  const roomById = this.page
+  const roomButton = this.page
+    .locator('[data-space-home-panel]')
     .locator(`[data-space-home-room-id="${channelId}"]`)
     .first()
-  const roomByName = this.page
-    .getByRole('button', { name: new RegExp(channelName, 'i') })
-    .first()
-  const roomButton = roomById.or(roomByName).first()
   await expect(roomButton).toBeVisible({ timeout: 45000 })
   await roomButton.click()
   await expect(this.page.locator('[data-space-home-panel]')).toHaveCount(0, {

--- a/tests/e2e/step-definitions/leave-room.steps.mjs
+++ b/tests/e2e/step-definitions/leave-room.steps.mjs
@@ -112,17 +112,28 @@ When('I select the seeded test space in the space rail', async function () {
   await spaceButton.click()
 })
 
-When('I open the seeded test space channel', async function () {
-  const channelId = requireEnv('E2E_TEST_SPACE_CHANNEL_ID')
-  const roomButton = this.page
+async function openSpaceChannelFromPanel(page, channelId) {
+  const roomButton = page
     .locator('[data-space-home-panel]')
     .locator(`[data-space-home-room-id="${channelId}"]`)
     .first()
   await expect(roomButton).toBeVisible({ timeout: 45000 })
   await roomButton.click()
-  await expect(this.page.locator('[data-space-home-panel]')).toHaveCount(0, {
+  await expect(page.locator('[data-space-home-panel]')).toHaveCount(0, {
     timeout: 30000,
   })
+}
+
+When('I open the seeded test space channel', async function () {
+  await openSpaceChannelFromPanel(this.page, seededSpaceChannelId())
+})
+
+function spaceHomeChannelId() {
+  return requireEnv('E2E_SPACE_HOME_CHANNEL_ID')
+}
+
+When('I open the seeded space home channel', async function () {
+  await openSpaceChannelFromPanel(this.page, spaceHomeChannelId())
 })
 
 When('I open the leave test dm room', async function () {

--- a/tests/e2e/step-definitions/leave-room.steps.mjs
+++ b/tests/e2e/step-definitions/leave-room.steps.mjs
@@ -108,7 +108,7 @@ When('I select the seeded test space in the space rail', async function () {
   const spaceButton = this.page
     .locator(`button[data-space-id="${spaceId}"]`)
     .first()
-  await expect(spaceButton).toBeVisible({ timeout: 20000 })
+  await expect(spaceButton).toBeVisible({ timeout: 60000 })
   await spaceButton.click()
 })
 

--- a/tests/e2e/support/hooks.mjs
+++ b/tests/e2e/support/hooks.mjs
@@ -17,6 +17,7 @@ const SYNAPSE_E2E_STEP_MARKERS = [
   'I open the side seeded test room',
   'leave test dm room',
   'seeded test space channel',
+  'seeded space home channel',
   'seeded test space in the space rail',
   'main test room',
   'seeded space channel',

--- a/tests/unit/composables/useChatSpaceRail.spec.ts
+++ b/tests/unit/composables/useChatSpaceRail.spec.ts
@@ -146,4 +146,46 @@ describe('useChatSpaceRail room selection', () => {
 
     expect(selectedRoomId.value).to.equal(channelId)
   })
+
+  it('keeps lobby channel selected before sidebar filter catches up', async () => {
+    const spaceId = '!space:example.org'
+    const channelId = '!channel:example.org'
+    const selectedSpaceId = ref<string | null>(spaceId)
+    const selectedRoomId = ref<string | null>(null)
+    const spaceLobbyRoomIds = ref<ReadonlySet<string>>(
+      new Set([channelId]),
+    )
+    const matrixRooms = ref([
+      createMatrixRoom(spaceId, {
+        name: 'Team',
+        type: 'm.space',
+      }),
+      createMatrixRoom(channelId, {
+        name: 'General',
+      }),
+    ] as never[])
+
+    const spaceRail = useChatSpaceRail({
+      client: ref(null),
+      matrixRooms,
+      selectedSpaceId,
+      selectedRoomId,
+      pendingRootSpaceId: ref(null),
+      translateText: (key) => key,
+      getSpaceAvatarUrl: () => undefined,
+      matrixSyncPrepared: ref(true),
+      spaceUnreadById: ref({}),
+      allMessages: ref([]),
+      messages: ref([]),
+      spaceLobbyRoomIds,
+    })
+
+    spaceRail.setupSpaceRailWatchers()
+    await nextTick()
+
+    selectedRoomId.value = channelId
+    await nextTick()
+
+    expect(selectedRoomId.value).to.equal(channelId)
+  })
 })

--- a/tests/unit/composables/useChatSpaceRail.spec.ts
+++ b/tests/unit/composables/useChatSpaceRail.spec.ts
@@ -10,15 +10,31 @@ function createMatrixRoom(
     type?: string
     parentSpaceIds?: string[]
     membership?: string
+    childRoomIds?: string[]
   } = {},
 ) {
+  const parentSpaceIds = options.parentSpaceIds ?? []
+  const childRoomIds = options.childRoomIds ?? []
   return {
     roomId,
     name: options.name ?? roomId,
     getType: () => options.type,
     getMyMembership: () => options.membership ?? 'join',
     currentState: {
-      getStateEvents: () => undefined,
+      getStateEvents: (eventType?: string) => {
+        if (eventType === 'm.space.parent' && parentSpaceIds.length > 0) {
+          return parentSpaceIds.map((spaceId) => ({
+            getStateKey: () => spaceId,
+          }))
+        }
+        if (eventType === 'm.space.child' && childRoomIds.length > 0) {
+          return childRoomIds.map((childRoomId) => ({
+            getStateKey: () => childRoomId,
+            getContent: () => ({}),
+          }))
+        }
+        return undefined
+      },
     },
   }
 }
@@ -90,5 +106,44 @@ describe('useChatSpaceRail room selection', () => {
 
     expect(selectedRoomId.value).toBeNull()
     expect(selectedRoomId.value).not.to.equal(otherRoomId)
+  })
+
+  it('keeps room selected when channel is linked via m.space.child only', async () => {
+    const spaceId = '!space:example.org'
+    const channelId = '!channel:example.org'
+    const selectedSpaceId = ref<string | null>(spaceId)
+    const selectedRoomId = ref<string | null>(null)
+    const matrixRooms = ref([
+      createMatrixRoom(spaceId, {
+        name: 'Team',
+        type: 'm.space',
+        childRoomIds: [channelId],
+      }),
+      createMatrixRoom(channelId, {
+        name: 'General',
+      }),
+    ] as never[])
+
+    const spaceRail = useChatSpaceRail({
+      client: ref(null),
+      matrixRooms,
+      selectedSpaceId,
+      selectedRoomId,
+      pendingRootSpaceId: ref(null),
+      translateText: (key) => key,
+      getSpaceAvatarUrl: () => undefined,
+      matrixSyncPrepared: ref(true),
+      spaceUnreadById: ref({}),
+      allMessages: ref([]),
+      messages: ref([]),
+    })
+
+    spaceRail.setupSpaceRailWatchers()
+    await nextTick()
+
+    selectedRoomId.value = channelId
+    await nextTick()
+
+    expect(selectedRoomId.value).to.equal(channelId)
   })
 })


### PR DESCRIPTION
- Updated CHANGELOG to document the inclusion of `m.space.child`-linked channels in `visibleRooms`, ensuring lobby channel selection retains `selectedRoomId` and hides the panel.
- Modified `useChatSpaceRail` to improve room filtering logic, allowing for better management of room selections based on space hierarchy.
- Adjusted E2E tests to remove WIP tags for scenarios related to leaving rooms and selecting spaces, streamlining test execution.
- Increased timeout for visibility checks in E2E tests to enhance reliability during room selection interactions.
- Added unit tests to verify the functionality of room selection when linked via `m.space.child`, ensuring robust coverage for new features.