### PR TITLE
Enhance E2E leave room functionality and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- E2E leave sidebar (cluster D): dedicated `E2E_LEAVE_GROUP_ROOM_ID`
+  seed isolates the group-leave scenario from the unread side room;
+  scoped Home-sidebar locators and sync waits in leave-room steps;
+  re-enable both `@leave_room` Home scenarios (34/34 green lane)
+  ([#137](https://github.com/mjkatgithub/Decentra/issues/137))
+
 - Space home panel: include `m.space.child`-linked channels in
   `visibleRooms`; keep lobby channel selection when sidebar filter lags;
   scope space-home E2E click to the panel; isolate `@space_home` with a

--- a/tests/e2e/features/chat.feature
+++ b/tests/e2e/features/chat.feature
@@ -325,20 +325,20 @@ Feature: Chat
       | away     |
       | offline  |
 
-  @leave_room @wip
-  Scenario: Leave side seeded group room from sidebar
+  @leave_room
+  Scenario: Leave seeded group room from sidebar
     When I open the login page
     And I sign in with configured credentials
     And I select Home in the space rail
-    And I open the side seeded test room for leave
-    And I open the channel options menu for the side seeded test room
+    And I open the leave test group room
+    And I open the channel options menu for the leave test group room
     And I choose leave channel from the menu
     And I confirm leaving the channel
     Then I should see the chat home onboarding panel
     And I should not be able to send messages in chat
-    And the side seeded test room should not appear in the sidebar
+    And the leave test group room should not appear in the sidebar
     When I reload the current page
-    Then the side seeded test room should not appear in the sidebar
+    Then the leave test group room should not appear in the sidebar
 
   @leave_room
   Scenario: Leave seeded space channel from sidebar
@@ -361,7 +361,7 @@ Feature: Chat
     When I open the seeded space home channel
     Then I should not see the space home panel
 
-  @leave_room @wip
+  @leave_room
   Scenario: Leave seeded direct message room from sidebar
     When I open the login page
     And I sign in with configured credentials

--- a/tests/e2e/scripts/runtime-seed-synapse.mjs
+++ b/tests/e2e/scripts/runtime-seed-synapse.mjs
@@ -13,6 +13,8 @@ const homeserver = process.env.E2E_LOCAL_HOMESERVER || 'http://127.0.0.1:8008'
 const roomName = process.env.E2E_TEST_ROOM_NAME || 'Decentra E2E Room'
 const sideRoomName =
   process.env.E2E_SIDE_TEST_ROOM_NAME || 'Decentra E2E Side Room'
+const leaveGroupRoomName =
+  process.env.E2E_LEAVE_GROUP_ROOM_NAME || 'Decentra E2E Leave Group Room'
 const primaryLocalpart = process.env.E2E_PRIMARY_LOCALPART || 'e2e-alice'
 const primaryPassword = process.env.E2E_PRIMARY_PASSWORD || 'e2e-alice-pass'
 const secondaryLocalpart = process.env.E2E_SECONDARY_LOCALPART || 'e2e-bob'
@@ -343,7 +345,21 @@ async function main() {
     },
   )
   const sideRoomId = sideRoomResponse.room_id
-  logStep('main + side rooms created')
+
+  const leaveGroupRoomResponse = await withAuth(
+    primarySession.access_token,
+    '/_matrix/client/v3/createRoom',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        name: leaveGroupRoomName,
+        invite: [secondarySession.user_id],
+        preset: 'private_chat',
+      }),
+    },
+  )
+  const leaveGroupRoomId = leaveGroupRoomResponse.room_id
+  logStep('main + side + leave group rooms created')
 
   const spaceName = process.env.E2E_TEST_SPACE_NAME || 'Decentra E2E Space'
   const spaceChannelName =
@@ -388,6 +404,11 @@ async function main() {
   await withAuth(
     secondarySession.access_token,
     `/_matrix/client/v3/rooms/${encodeURIComponent(sideRoomId)}/join`,
+    { method: 'POST', body: '{}' },
+  )
+  await withAuth(
+    secondarySession.access_token,
+    `/_matrix/client/v3/rooms/${encodeURIComponent(leaveGroupRoomId)}/join`,
     { method: 'POST', body: '{}' },
   )
   await withAuth(
@@ -529,6 +550,8 @@ async function main() {
     `E2E_TEST_ROOM_ID=${roomId}`,
     `E2E_SIDE_TEST_ROOM_NAME=${sideRoomName}`,
     `E2E_SIDE_TEST_ROOM_ID=${sideRoomId}`,
+    `E2E_LEAVE_GROUP_ROOM_NAME=${leaveGroupRoomName}`,
+    `E2E_LEAVE_GROUP_ROOM_ID=${leaveGroupRoomId}`,
     `E2E_TEST_SPACE_NAME=${spaceName}`,
     `E2E_TEST_SPACE_ID=${spaceId}`,
     `E2E_TEST_SPACE_CHANNEL_NAME=${spaceChannelName}`,

--- a/tests/e2e/step-definitions/leave-room.steps.mjs
+++ b/tests/e2e/step-definitions/leave-room.steps.mjs
@@ -9,8 +9,8 @@ function requireEnv(variableName) {
   return variableValue
 }
 
-function sideTestRoomId() {
-  return requireEnv('E2E_SIDE_TEST_ROOM_ID')
+function leaveGroupRoomId() {
+  return requireEnv('E2E_LEAVE_GROUP_ROOM_ID')
 }
 
 function seededSpaceChannelId() {
@@ -21,17 +21,45 @@ function leaveDmRoomId() {
   return requireEnv('E2E_LEAVE_DM_ROOM_ID')
 }
 
-function roomButtonById(page, roomId) {
-  return page.locator(`button[data-room-id="${roomId}"]`).first()
+function homeSidebar(page) {
+  return page.locator('.decentra-shell > aside').first()
+}
+
+function homeSidebarRoomButton(page, roomId) {
+  return homeSidebar(page)
+    .locator(`button[data-room-id="${roomId}"]`)
+    .first()
+}
+
+function homeSidebarRoomActionsButton(page, roomId) {
+  return homeSidebar(page)
+    .locator(`button[data-room-actions="${roomId}"]`)
+    .first()
+}
+
+async function waitForHomeSidebarReady(page) {
+  const sidebarRooms = homeSidebar(page).locator('button[data-room-id]')
+  await expect(sidebarRooms.first()).toBeVisible({ timeout: 60000 })
+}
+
+async function openHomeSidebarRoom(page, roomId, nameFallbackPattern) {
+  await waitForHomeSidebarReady(page)
+  let roomButton = homeSidebarRoomButton(page, roomId)
+  if ((await roomButton.count()) === 0 && nameFallbackPattern) {
+    roomButton = homeSidebar(page)
+      .getByRole('button', { name: nameFallbackPattern })
+      .first()
+  }
+  await expect(roomButton).toBeVisible({ timeout: 60000 })
+  await roomButton.scrollIntoViewIfNeeded()
+  await roomButton.click({ force: true })
 }
 
 async function openChannelOptionsMenu(page, roomId) {
-  const roomButton = roomButtonById(page, roomId)
+  const roomButton = homeSidebarRoomButton(page, roomId)
   await expect(roomButton).toBeVisible({ timeout: 20000 })
   await roomButton.hover()
-  const actionsButton = page
-    .locator(`button[data-room-actions="${roomId}"]`)
-    .first()
+  const actionsButton = homeSidebarRoomActionsButton(page, roomId)
   await expect(actionsButton).toBeVisible({ timeout: 10000 })
   await actionsButton.click()
 }
@@ -78,29 +106,30 @@ async function assertSpaceHomePanel(page) {
   })
 }
 
-async function assertRoomAbsentFromSidebar(page, roomId) {
-  await expect(roomButtonById(page, roomId)).toHaveCount(0, {
+async function assertRoomAbsentFromHomeSidebar(page, roomId) {
+  await expect(homeSidebarRoomButton(page, roomId)).toHaveCount(0, {
     timeout: 20000,
   })
 }
 
-When('I open the side seeded test room for leave', async function () {
-  const roomId = requireEnv('E2E_SIDE_TEST_ROOM_ID')
+When('I open the leave test group room', async function () {
+  const roomId = leaveGroupRoomId()
   const roomName =
-    process.env.E2E_SIDE_TEST_ROOM_NAME || 'Decentra E2E Side Room'
-  const roomButton = roomButtonById(this.page, roomId)
-    .or(this.page.getByRole('button', { name: new RegExp(roomName, 'i') }))
-    .first()
-  await expect(roomButton).toBeVisible({ timeout: 60000 })
-  await roomButton.click()
+    process.env.E2E_LEAVE_GROUP_ROOM_NAME || 'Decentra E2E Leave Group Room'
+  await openHomeSidebarRoom(
+    this.page,
+    roomId,
+    new RegExp(roomName, 'i'),
+  )
 })
 
 When('I select Home in the space rail', async function () {
   const homeButton = this.page
     .locator('button[data-space-id="__home__"]')
     .first()
-  await expect(homeButton).toBeVisible({ timeout: 20000 })
+  await expect(homeButton).toBeVisible({ timeout: 60000 })
   await homeButton.click()
+  await waitForHomeSidebarReady(this.page)
 })
 
 When('I select the seeded test space in the space rail', async function () {
@@ -141,17 +170,17 @@ When('I open the leave test dm room', async function () {
   const peerName = requireEnv('E2E_SECOND_MATRIX_USERNAME')
     .split(':')[0]
     .replace('@', '')
-  const roomButton = roomButtonById(this.page, roomId)
-    .or(this.page.getByRole('button', { name: new RegExp(peerName, 'i') }))
-    .first()
-  await expect(roomButton).toBeVisible({ timeout: 60000 })
-  await roomButton.click()
+  await openHomeSidebarRoom(
+    this.page,
+    roomId,
+    new RegExp(peerName, 'i'),
+  )
 })
 
 When(
-  'I open the channel options menu for the side seeded test room',
+  'I open the channel options menu for the leave test group room',
   async function () {
-    await openChannelOptionsMenu(this.page, sideTestRoomId())
+    await openChannelOptionsMenu(this.page, leaveGroupRoomId())
   },
 )
 
@@ -191,23 +220,26 @@ Then('I should not see the space home panel', async function () {
 })
 
 Then(
-  'the side seeded test room should not appear in the sidebar',
+  'the leave test group room should not appear in the sidebar',
   async function () {
-    await assertRoomAbsentFromSidebar(this.page, sideTestRoomId())
+    await assertRoomAbsentFromHomeSidebar(this.page, leaveGroupRoomId())
   },
 )
 
 Then(
   'the seeded test space channel should not appear in the sidebar',
   async function () {
-    await assertRoomAbsentFromSidebar(this.page, seededSpaceChannelId())
+    await assertRoomAbsentFromHomeSidebar(
+      this.page,
+      seededSpaceChannelId(),
+    )
   },
 )
 
 Then(
   'the leave test dm room should not appear in the sidebar',
   async function () {
-    await assertRoomAbsentFromSidebar(this.page, leaveDmRoomId())
+    await assertRoomAbsentFromHomeSidebar(this.page, leaveDmRoomId())
   },
 )
 

--- a/tests/e2e/support/hooks.mjs
+++ b/tests/e2e/support/hooks.mjs
@@ -15,6 +15,7 @@ loadE2EEnv(resolve(process.cwd()))
 const SYNAPSE_E2E_STEP_MARKERS = [
   'I open the seeded test room',
   'I open the side seeded test room',
+  'leave test group room',
   'leave test dm room',
   'seeded test space channel',
   'seeded space home channel',


### PR DESCRIPTION
- Introduced a dedicated `E2E_LEAVE_GROUP_ROOM_ID` seed to isolate the group-leave scenario from the unread side room, improving test reliability.
- Updated E2E tests to re-enable both `@leave_room` scenarios, ensuring all tests pass successfully.
- Refactored step definitions to streamline interactions with the leave test group room, enhancing clarity and maintainability.
- Documented these changes in the CHANGELOG to reflect the improvements in E2E testing for leave room functionality.